### PR TITLE
Raise error on old pytorch version

### DIFF
--- a/cebra/models/model.py
+++ b/cebra/models/model.py
@@ -674,6 +674,10 @@ class Offset36Dropout(_OffsetModel, ConvolutionalModelMixin):
     """CEBRA model with a 10 sample receptive field."""
 
     def __init__(self, num_neurons, num_units, num_output, normalize=True):
+        if torch.__version__ < '1.12':
+            raise ImportError(
+                f"PyTorch < 1.12 is not supported for models using "
+                f"Dropout1D, but got PyTorch={torch.__version__}.")
         if num_units < 1:
             raise ValueError(
                 f"Hidden dimension needs to be at least 1, but got {num_units}."
@@ -721,6 +725,10 @@ class Offset36Dropoutv2(_OffsetModel, ConvolutionalModelMixin):
         ]
 
     def __init__(self, num_neurons, num_units, num_output, normalize=True):
+        if torch.__version__ < '1.12':
+            raise ImportError(
+                f"PyTorch < 1.12 is not supported for models using "
+                f"Dropout1D, but got PyTorch={torch.__version__}.")
         if num_units < 1:
             raise ValueError(
                 f"Hidden dimension needs to be at least 1, but got {num_units}."

--- a/cebra/models/model.py
+++ b/cebra/models/model.py
@@ -24,6 +24,31 @@ import cebra.models.layers as cebra_layers
 from cebra.models import register
 
 
+def _check_torch_version(raise_error=False):
+    current_version = tuple(
+        [int(i) for i in torch.__version__.split(".")[:2] if len(i) > 0])
+    required_version = (1, 12)
+    if current_version < required_version:
+        if raise_error:
+            raise ImportError(
+                f"PyTorch < 1.12 is not supported for models using "
+                f"Dropout1D, but got PyTorch={torch.__version__}.")
+        else:
+            return False
+    return True
+
+
+def _register_conditionally(*args, **kwargs):
+    if _check_torch_version(raise_error=False):
+        return register(*args, **kwargs)
+    else:
+
+        def do_nothing(cls):
+            return cls
+
+        return do_nothing
+
+
 class Model(nn.Module):
     """Base model for CEBRA experiments.
 
@@ -669,15 +694,15 @@ class Offset36(_OffsetModel, ConvolutionalModelMixin):
         return cebra.data.Offset(18, 18)
 
 
-@register("offset36-model-dropout")
+@_register_conditionally("offset36-model-dropout")
 class Offset36Dropout(_OffsetModel, ConvolutionalModelMixin):
-    """CEBRA model with a 10 sample receptive field."""
+    """CEBRA model with a 10 sample receptive field.
+    
+    Note:
+        Requires ``torch>=1.12``.
+    """
 
     def __init__(self, num_neurons, num_units, num_output, normalize=True):
-        if torch.__version__ < '1.12':
-            raise ImportError(
-                f"PyTorch < 1.12 is not supported for models using "
-                f"Dropout1D, but got PyTorch={torch.__version__}.")
         if num_units < 1:
             raise ValueError(
                 f"Hidden dimension needs to be at least 1, but got {num_units}."
@@ -713,9 +738,13 @@ class Offset36Dropout(_OffsetModel, ConvolutionalModelMixin):
         return cebra.data.Offset(18, 18)
 
 
-@register("offset36-model-more-dropout")
+@_register_conditionally("offset36-model-more-dropout")
 class Offset36Dropoutv2(_OffsetModel, ConvolutionalModelMixin):
-    """CEBRA model with a 10 sample receptive field."""
+    """CEBRA model with a 10 sample receptive field.
+    
+    Note:
+        Requires ``torch>=1.12``.
+    """
 
     def _make_layers(self, num_units, p, n):
         return [
@@ -725,10 +754,6 @@ class Offset36Dropoutv2(_OffsetModel, ConvolutionalModelMixin):
         ]
 
     def __init__(self, num_neurons, num_units, num_output, normalize=True):
-        if torch.__version__ < '1.12':
-            raise ImportError(
-                f"PyTorch < 1.12 is not supported for models using "
-                f"Dropout1D, but got PyTorch={torch.__version__}.")
         if num_units < 1:
             raise ValueError(
                 f"Hidden dimension needs to be at least 1, but got {num_units}."

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -143,3 +143,11 @@ def test_version_check(version, raises):
     if raises:
         with pytest.raises(ImportError):
             cebra.models.model._check_torch_version(raise_error=True)
+
+
+def test_version_check():
+    raises = not cebra.models.model._check_torch_version(raise_error=False)
+    if raises:
+        assert len(cebra.models.get_options("*dropout*")) == 0
+    else:
+        assert len(cebra.models.get_options("*dropout*")) > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -122,3 +122,24 @@ def test_multiobjective():
     assert first.shape == (5, 4)
     assert second.shape == (5, 2)
     assert third.shape == (5, 4)
+
+
+@pytest.mark.parametrize("version,raises", [
+    ["1.12", False],
+    ["2.", False],
+    ["2.0.0rc", False],
+    ["2.0", False],
+    ["2.5", False],
+    ["1.11.0rc1", True],
+    ["1.10", True],
+    ["1.2", True],
+    ["1.0", True],
+])
+def test_version_check(version, raises):
+
+    torch.__version__ = version
+    assert cebra.models.model._check_torch_version(
+        raise_error=False) == (not raises)
+    if raises:
+        with pytest.raises(ImportError):
+            cebra.models.model._check_torch_version(raise_error=True)


### PR DESCRIPTION
Some newer models require pytorch >= 1.12. To avoid making this a hard dependency, this PR adds functionality to check the pytorch version, and only registers compatible models.