### PR TITLE
Release 0.2.0rc4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           make codespell
 
+      - name: Check CITATION.cff validity
+        run: |
+          cffconvert --validate
+
       - name: Check that no binary files have been added to repo
         run: |
           make check_for_binary

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,29 +1,40 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
+title: >-
+  Learnable latent embeddings for joint behavioural and
+  neural analysis
 authors:
-- family-names: "Schneider"
-  given-names: "Steffen"
-- family-names: "Lee"
-  given-names: "Jin H"
-- family-names: "Mathis"
-  given-names: "Mackenzie W"
-title: "Learnable latent embeddings for joint behavioral and neural analysis"
-doi: abs/2204.00673
-date-released: 2022-04-01
-url: "https://arxiv.org/abs/2204.00673"
-preferred-citation:
-  type: article
-  authors:
-  - family-names: "Schneider"
-    given-names: "Steffen"
-  - family-names: "Lee"
-    given-names: "Jin H"
-  - family-names: "Mathis"
-    given-names: "Mackenzie W"
-  doi: abs/2204.00673
-  journal: "CoRR"
-  month: 04
-  title: "Learnable latent embeddings for joint behavioral and neural analysis"
-  volume: abs/2204.00673
-  year: 2022
+  - given-names: "Steffen"
+    family-names: "Schneider"
+  - given-names: "Jin Hwa"
+    family-names: "Lee"
+  - given-names: "Mackenzie Weygandt"
+    family-names: "Mathis"
+identifiers:
+  - type: url
+    value: 'https://www.nature.com/articles/s41586-023-06031-6'
+  - type: doi
+    value: 10.1038/s41586-023-06031-6
+repository-code: 'https://github.com/AdaptiveMotorControlLab/CEBRA'
 
+preferred-citation:
+  title: >-
+    Learnable latent embeddings for joint behavioural and
+    neural analysis
+  authors:
+    - given-names: "Steffen"
+      family-names: "Schneider"
+    - given-names: "Jin Hwa"
+      family-names: "Lee"
+    - given-names: "Mackenzie Weygandt"
+      family-names: "Mathis"
+  type: "article"
+  journal: "Nature"
+  year: 2023
+  month: 05
+  doi: 10.1038/s41586-023-06031-6
+  issn: 1476-4687
+  url: https://doi.org/10.1038/s41586-023-06031-6

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: dist
 archlinux:
 	mkdir -p dist/arch
 	cp PKGBUILD dist/arch 
-	cp dist/cebra-0.2.0rc3.tar.gz dist/arch 
+	cp dist/cebra-0.2.0rc4.tar.gz dist/arch 
 	(cd dist/arch; makepkg --skipchecksums -f)
 
 # NOTE(stes): Ensure that no old tempfiles are present. Ideally, move this into

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Steffen Schneider <stes@hey.com>
 pkgname=python-cebra
 _pkgname=cebra
-pkgver=0.2.0rc3
+pkgver=0.2.0rc4
 pkgrel=1
 pkgdesc="Consistent Embeddings of high-dimensional Recordings using Auxiliary variables"
 url="https://cebra.ai"

--- a/cebra/__init__.py
+++ b/cebra/__init__.py
@@ -47,7 +47,7 @@ except (ImportError, NameError):
 
 import cebra.integrations.sklearn as sklearn
 
-__version__ = "0.2.0rc3"
+__version__ = "0.2.0rc4"
 __all__ = ["CEBRA"]
 __allow_lazy_imports = False
 __lazy_imports = {}

--- a/docs/root/index.html
+++ b/docs/root/index.html
@@ -111,7 +111,7 @@
                         <a href="https://jinhl9.github.io/" target="_blank"><i class="fas fa-link"></i></a>
                     </div>
                     <div class="col-md-2  mb-4">
-                        Mackenzie Weygandt Mathis</br>
+                        Mackenzie Mathis</br>
                         EPFL
                         <a href="mailto:mackenzie.mathis@epfl.ch"><i class="far fa-envelope"></i></a>
                         <a href="https://www.mackenziemathislab.org/mackenziemathis" target="_blank"><i class="fas fa-link"></i></a>
@@ -258,25 +258,29 @@
                     BibTeX</h3>
                 </div>
                 <div class="row">
-                    <p>Please cite our pre-print as follows:</p>
+                    <p>Please cite our paper as follows:</p>
                 </div>
                 <div class="row justify-content-md-center">
                     <div class="col-sm-10 rounded p-3 m-2" style="background-color: rgb(20,20,20);">
                         <small class="code">
-                            @article{schneider2022cebra,<br>
-                            &nbsp;&nbsp;author = {Schneider, Steffen and Lee, Jin H and Mathis, Mackenzie W},<br>
-                            &nbsp;&nbsp;title = {Learnable latent embeddings for joint behavioral and neural analysis},<br>
-                            &nbsp;&nbsp;doi = {10.48550/ARXIV.2204.00673},<br>
-                            &nbsp;&nbsp;url = {https://arxiv.org/abs/2204.00673},<br>
-                            &nbsp;&nbsp;journal = {CoRR},<br>
-                            &nbsp;&nbsp;volume = {abs/2204.00673},<br>
-                            &nbsp;&nbsp;year = {2022},<br>
+                            @article{schneider2023cebra,<br/>
+                            &nbsp;&nbsp;author={<br/>
+                            &nbsp;&nbsp;&nbsp;&nbsp;Schneider, Steffen and<br/>
+                            &nbsp;&nbsp;&nbsp;&nbsp;Lee, Jin Hwa and<br/>
+                            &nbsp;&nbsp;&nbsp;&nbsp;Mathis, Mackenzie Weygandt<br/>
+                            &nbsp;&nbsp;},<br/>
+                            &nbsp;&nbsp;title={Learnable latent embeddings for joint behavioural and neural analysis},<br/>
+                            &nbsp;&nbsp;journal={Nature},<br/>
+                            &nbsp;&nbsp;year={2023},<br/>
+                            &nbsp;&nbsp;month={May},<br/>
+                            &nbsp;&nbsp;day={03},<br/>
+                            &nbsp;&nbsp;issn={1476-4687},<br/>
+                            &nbsp;&nbsp;doi={10.1038/s41586-023-06031-6},<br/>
+                            &nbsp;&nbsp;url={https://doi.org/10.1038/s41586-023-06031-6}<br/>
                             }
                         </small>
                     </div>
                 </div>
-
-                
 
                 <div class="row">
                     <small class="text-muted">Webpage designed using Bootstrap 5 and Fontawesome 5.</small>

--- a/docs/root/index.html
+++ b/docs/root/index.html
@@ -264,11 +264,7 @@
                     <div class="col-sm-10 rounded p-3 m-2" style="background-color: rgb(20,20,20);">
                         <small class="code">
                             @article{schneider2023cebra,<br/>
-                            &nbsp;&nbsp;author={<br/>
-                            &nbsp;&nbsp;&nbsp;&nbsp;Schneider, Steffen and<br/>
-                            &nbsp;&nbsp;&nbsp;&nbsp;Lee, Jin Hwa and<br/>
-                            &nbsp;&nbsp;&nbsp;&nbsp;Mathis, Mackenzie Weygandt<br/>
-                            &nbsp;&nbsp;},<br/>
+                            &nbsp;&nbsp;author={Schneider, Steffen and Lee, Jin Hwa and Mathis, Mackenzie Weygandt},<br/>
                             &nbsp;&nbsp;title={Learnable latent embeddings for joint behavioural and neural analysis},<br/>
                             &nbsp;&nbsp;journal={Nature},<br/>
                             &nbsp;&nbsp;year={2023},<br/>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -161,7 +161,7 @@ html_theme_options = {
         },
         {
             "name": "How to cite CEBRA",
-            "url": "https://api.semanticscholar.org/CorpusID:247939478",
+            "url": "https://doi.org/10.1038/s41586-023-06031-6#citeas",
             "icon": "fas fa-graduation-cap",
         },
     ],

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -18,8 +18,10 @@ Installation Guide
 ------------------
 
 We outline installation instructions for different systems. 
-CEBRA will be installed via ``pip``. Its dependencies can be installed using ``pip``, ``conda`` or
-``docker`` and we outline different options below.
+CEBRA will be installed via ``pip install cebra``.
+
+Its dependencies can be installed using ``pip`` or ``conda`` and
+we outline different options below.
 
 Most users can only install the **minimal install**. 🚀 For more advanced users, CEBRA has different extra install options that you can select based on your usecase:
 
@@ -35,7 +37,15 @@ Most users can only install the **minimal install**. 🚀 For more advanced user
 
     .. tab:: Google Colab
 
-        CEBRA can also be installed and run on Google colaboratory. Please see the ``open in colab`` button at the top of each demo notebook for examples. 
+        CEBRA can also be installed and run on Google colaboratory.
+        Please see the ``open in colab`` button at the top of each demo notebook for examples. 
+
+        If you are starting with a new notebook, simply run
+
+        .. code:: bash
+            ! pip install cebra
+
+        In the first cell.
 
 
     .. tab:: Supplied conda (CEBRA)
@@ -133,31 +143,6 @@ Most users can only install the **minimal install**. 🚀 For more advanced user
         .. note::
             On windows systems, you will need to drop the quotation marks and install via ``pip install .[dev]``.
 
-    .. tab:: Docker
-
-        A ``Dockerfile`` for running CEBRA is provided in the ``docker/`` sub-directory.
-        It is possible to start a full development environment by running ``make interact``.
-        Alternatively, the container can be build locally. Refer to ``make docker`` in the ``Makefile``.
-
-        .. code:: bash
-
-            $ make docker 
-            $ make interact 
-            $ make test
-            
-        Several arguments can be used to configure the docker container.
-        The currently supported docker images for different CUDA versions installed locally are:
-        ``docker-10.1-runtime-ubuntu18.04``, ``docker-10.2-runtime-ubuntu18.04`` and ``docker-11.1-runtime-ubuntu20.04``, but more images can be easily added by modifying the Dockerfile.
-
-        A particular version can be built and run by executing
-
-        .. code:: bash
-
-            $ make docker-11.1-runtime-ubuntu20.04
-            $ make interact-11.1-runtime-ubuntu20.04
-
-        All images are based on the official `Nvidia CUDA Docker images <https://hub.docker.com/r/nvidia/cuda>`_.
-
     .. tab:: pip
 
         .. note::
@@ -181,17 +166,11 @@ Most users can only install the **minimal install**. 🚀 For more advanced user
 
             $ pip install cebra
 
-        * For a minimal install, use
-
-        .. code:: bash
-
-            $ pip install .
-
         * For a full install, run
 
         .. code:: bash
 
-            $ pip install -e '.[dev,docs,integrations,datasets]'
+            $ pip install 'cebra[dev,integrations,datasets]'
 
         Note that, similarly to that last command, you can select the specific install options of interest based on their description above and on your usecase.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -43,6 +43,7 @@ Most users can only install the **minimal install**. 🚀 For more advanced user
         If you are starting with a new notebook, simply run
 
         .. code:: bash
+
             ! pip install cebra
 
         In the first cell.

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -15,7 +15,7 @@ pip uninstall -y cebra
 # Get version info after uninstalling --- this will automatically get the
 # most recent version based on the source code in the current directory.
 # $(tools/get_cebra_version.sh)
-VERSION=0.2.0rc3
+VERSION=0.2.0rc4
 echo "Upgrading to CEBRA v${VERSION}"
 
 # Upgrade the build system (PEP517/518 compatible)

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ dev =
     # is resolved.
     # docformatter[tomli]
     codespell
+    cffconvert
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
- Several updates of references to the now [released paper](https://www.nature.com/articles/s41586-023-06031-6) in README, docs, and CITATION.cff
- Bump version to 0.2.0rc4