### PR TITLE
Remove `subsample` default in `OrthogonalProcrustesAlignment`, improve tests

### DIFF
--- a/cebra/data/helper.py
+++ b/cebra/data/helper.py
@@ -10,6 +10,7 @@
 # https://github.com/AdaptiveMotorControlLab/CEBRA/LICENSE.md
 #
 import copy
+import warnings
 from typing import List, Optional, Union
 
 import joblib
@@ -17,7 +18,6 @@ import numpy as np
 import numpy.typing as npt
 import scipy.linalg
 import torch
-import warnings
 
 
 def _require_numpy_array(array: Union[npt.NDArray, torch.Tensor]):
@@ -190,15 +190,13 @@ class OrthogonalProcrustesAlignment:
                     f"should be larger than the 'subsample' "
                     f"parameter ({self.subsample}). Ignoring subsampling and "
                     f"computing alignment on the full dataset instead, which will "
-                    f"give better results."
-                )
+                    f"give better results.")
             else:
                 if self.subsample < 1000:
                     warnings.warn(
                         "This function is experimental when the subsample dimension "
                         "is less than 1000. You can probably use the whole dataset "
-                        "for alignment by setting subsample=None."
-                    )
+                        "for alignment by setting subsample=None.")
 
                 idc = np.random.choice(len(X), self.subsample)
                 X = X[idc]

--- a/cebra/data/helper.py
+++ b/cebra/data/helper.py
@@ -62,7 +62,7 @@ class OrthogonalProcrustesAlignment:
             Procrustes problem on.
     """
 
-    def __init__(self, top_k: int = 5, subsample: int = 500):
+    def __init__(self, top_k: int = 5, subsample: Optional[int] = None):
         self.subsample = subsample
         self.top_k = top_k
 

--- a/cebra/data/helper.py
+++ b/cebra/data/helper.py
@@ -185,11 +185,20 @@ class OrthogonalProcrustesAlignment:
         # Augment data and reference data so that same size
         if self.subsample is not None:
             if self.subsample > len(X):
-                warnings.warn(f"The number of datapoints in the dataset should be larger "
-                                 f"than the susbample dimension. Subsampling won't be performed.")
+                warnings.warn(
+                    f"The number of datapoints in the dataset ({len(X)}) "
+                    f"should be larger than the 'subsample' "
+                    f"parameter ({self.subsample}). Ignoring subsampling and "
+                    f"computing alignment on the full dataset instead, which will "
+                    f"give better results."
+                )
             else:
                 if self.subsample < 1000:
-                    warnings.warn(f"This function is experimental when the subsample dimension is less than 1000.")
+                    warnings.warn(
+                        "This function is experimental when the subsample dimension "
+                        "is less than 1000. You can probably use the whole dataset "
+                        "for alignment by setting subsample=None."
+                    )
 
                 idc = np.random.choice(len(X), self.subsample)
                 X = X[idc]

--- a/cebra/data/helper.py
+++ b/cebra/data/helper.py
@@ -17,6 +17,7 @@ import numpy as np
 import numpy.typing as npt
 import scipy.linalg
 import torch
+import warnings
 
 
 def _require_numpy_array(array: Union[npt.NDArray, torch.Tensor]):
@@ -183,6 +184,13 @@ class OrthogonalProcrustesAlignment:
 
         # Augment data and reference data so that same size
         if self.subsample is not None:
+            if self.subsample > len(X):
+                raise ValueError(f"The number of datapoints in the dataset should be larger "
+                                 f"than the susbample dimension.")
+           
+            if self.subsample < 1000:
+                warnings.warn(f"This function is experimental when the subsample dimension is less than 1000.")
+                
             idc = np.random.choice(len(X), self.subsample)
             X = X[idc]
             Y = Y[idc]

--- a/cebra/data/helper.py
+++ b/cebra/data/helper.py
@@ -179,21 +179,21 @@ class OrthogonalProcrustesAlignment:
 
         # Get the whole data to align and only the selected closest samples
         # from the reference data.
-        X = data[:, None].repeat(5, axis=1).reshape(-1, data.shape[1])
+        X = data[:, None].repeat(self.top_k, axis=1).reshape(-1, data.shape[1])
         Y = ref_data[target_idx].reshape(-1, ref_data.shape[1])
 
         # Augment data and reference data so that same size
         if self.subsample is not None:
             if self.subsample > len(X):
-                raise ValueError(f"The number of datapoints in the dataset should be larger "
-                                 f"than the susbample dimension.")
-           
-            if self.subsample < 1000:
-                warnings.warn(f"This function is experimental when the subsample dimension is less than 1000.")
-                
-            idc = np.random.choice(len(X), self.subsample)
-            X = X[idc]
-            Y = Y[idc]
+                warnings.warn(f"The number of datapoints in the dataset should be larger "
+                                 f"than the susbample dimension. Subsampling won't be performed.")
+            else:
+                if self.subsample < 1000:
+                    warnings.warn(f"This function is experimental when the subsample dimension is less than 1000.")
+
+                idc = np.random.choice(len(X), self.subsample)
+                X = X[idc]
+                Y = Y[idc]
 
         # Compute orthogonal matrix that most closely maps X to Y using the orthogonal Procrustes problem.
         self._transform, _ = scipy.linalg.orthogonal_procrustes(X, Y)

--- a/tests/test_data_helper.py
+++ b/tests/test_data_helper.py
@@ -123,12 +123,12 @@ def test_orthogonal_alignment_shapes(ref_data, data, ref_labels, labels):
     assert _does_shape_match(data, aligned_embedding)
 
     # Test with non-default parameters
-    #alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment(
-    #    top_k=10)
-#
-#    aligned_embedding = alignment_model.fit_transform(ref_data, data,
-#                                                      ref_labels, labels)
-#    assert _does_shape_match(data, aligned_embedding), (data.shape, aligned_embedding.shape)
+    alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment(
+        top_k=10)
+
+    aligned_embedding = alignment_model.fit_transform(ref_data, data,
+                                                      ref_labels, labels)
+    assert _does_shape_match(data, aligned_embedding), (data.shape, aligned_embedding.shape)
 
 
 @pytest.mark.parametrize("ref_data,data,ref_labels,labels,match",

--- a/tests/test_data_helper.py
+++ b/tests/test_data_helper.py
@@ -290,16 +290,15 @@ def test_invalid_embedding_ensembling(embeddings, labels, n_jobs, match):
             n_jobs=n_jobs,
         )
 
-
-def test_embedding_ensembling():
-    random_seed = 27
-    np.random.seed(random_seed)
+@pytest.mark.parametrize("seed", [483, 426, 166, 674, 123])
+def test_embedding_ensembling(seed):
+    np.random.seed(seed)
     embedding_100_4d = np.random.uniform(0, 1, (100, 4))
     labels_100_1d = np.random.uniform(0, 1, (100, 1))
     orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4,
-                                                    random_state=random_seed)
+                                                    random_state=seed)
     orthogonal_matrix_2 = scipy.stats.ortho_group.rvs(dim=4,
-                                                      random_state=random_seed +
+                                                      random_state=seed +
                                                       1)
 
     embedding_100_4d_2 = np.dot(embedding_100_4d, orthogonal_matrix)
@@ -310,11 +309,11 @@ def test_embedding_ensembling():
     joint_embedding = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2, embedding_100_4d_3],
         labels=labels)
-    assert np.allclose(joint_embedding, embedding_100_4d)
+    assert np.allclose(joint_embedding, embedding_100_4d, atol = 0.05)
 
     joint_embedding = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2, embedding_100_4d_3])
-    assert np.allclose(joint_embedding, embedding_100_4d)
+    assert np.allclose(joint_embedding, embedding_100_4d, atol = 0.05)
 
 
 @pytest.mark.benchmark

--- a/tests/test_data_helper.py
+++ b/tests/test_data_helper.py
@@ -123,12 +123,12 @@ def test_orthogonal_alignment_shapes(ref_data, data, ref_labels, labels):
     assert _does_shape_match(data, aligned_embedding)
 
     # Test with non-default parameters
-    alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment(
-        top_k=10, subsample=1000)
-
-    aligned_embedding = alignment_model.fit_transform(ref_data, data,
-                                                      ref_labels, labels)
-    assert _does_shape_match(data, aligned_embedding)
+    #alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment(
+    #    top_k=10)
+#
+#    aligned_embedding = alignment_model.fit_transform(ref_data, data,
+#                                                      ref_labels, labels)
+#    assert _does_shape_match(data, aligned_embedding), (data.shape, aligned_embedding.shape)
 
 
 @pytest.mark.parametrize("ref_data,data,ref_labels,labels,match",
@@ -144,8 +144,8 @@ def test_invalid_orthogonal_alignment(ref_data, data, ref_labels, labels,
 def test_orthogonal_alignment_without_labels():
     random_seed = 2160
     np.random.seed(random_seed)
-    embedding_100_4d = np.random.uniform(0, 1, (100, 4))
-    embedding_100_4d_2 = np.random.uniform(0, 1, (100, 4))
+    embedding_100_4d = np.random.uniform(0, 1, (1000, 4))
+    embedding_100_4d_2 = np.random.uniform(0, 1, (1000, 4))
 
     alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment()
 
@@ -157,17 +157,16 @@ def test_orthogonal_alignment_without_labels():
         embedding_100_4d_2)
 
     assert np.allclose(aligned_embedding,
-                       aligned_embedding_without_labels,
-                       atol=0.1)
+                       aligned_embedding_without_labels)
 
 
 def test_orthogonal_alignment():
     random_seed = 483
     np.random.seed(random_seed)
-    embedding_100_4d = np.random.uniform(0, 1, (100, 4))
+    embedding_100_4d = np.random.uniform(0, 1, (5000, 4))
     orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4,
                                                     random_state=random_seed)
-    labels_100_1d = np.random.uniform(0, 1, (100, 1))
+    labels_100_1d = np.random.uniform(0, 1, (1000, 1))
 
     alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment()
     aligned_embedding = alignment_model.fit_transform(ref_data=embedding_100_4d,
@@ -176,14 +175,14 @@ def test_orthogonal_alignment():
                                                           orthogonal_matrix),
                                                       ref_label=labels_100_1d,
                                                       label=labels_100_1d)
-    assert np.allclose(aligned_embedding, embedding_100_4d, atol=0.05)
+    assert np.allclose(aligned_embedding, embedding_100_4d)
 
     # and without labels
     aligned_embedding = alignment_model.fit_transform(ref_data=embedding_100_4d,
                                                       data=np.dot(
                                                           embedding_100_4d,
                                                           orthogonal_matrix))
-    assert np.allclose(aligned_embedding, embedding_100_4d, atol=0.05)
+    assert np.allclose(aligned_embedding, embedding_100_4d)
 
 
 def _initialize_embedding_ensembling_data():
@@ -278,8 +277,7 @@ def test_embeddings_ensembling_without_labels():
     joint_embedding_without_labels = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2])
     assert np.allclose(joint_embedding,
-                       joint_embedding_without_labels,
-                       atol=0.05)
+                       joint_embedding_without_labels)
 
 
 @pytest.mark.parametrize("embeddings,labels,n_jobs,match",
@@ -312,11 +310,11 @@ def test_embedding_ensembling():
     joint_embedding = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2, embedding_100_4d_3],
         labels=labels)
-    assert np.allclose(joint_embedding, embedding_100_4d, atol=0.05)
+    assert np.allclose(joint_embedding, embedding_100_4d)
 
     joint_embedding = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2, embedding_100_4d_3])
-    assert np.allclose(joint_embedding, embedding_100_4d, atol=0.05)
+    assert np.allclose(joint_embedding, embedding_100_4d)
 
 
 @pytest.mark.benchmark

--- a/tests/test_data_helper.py
+++ b/tests/test_data_helper.py
@@ -160,12 +160,12 @@ def test_orthogonal_alignment_without_labels():
                        aligned_embedding_without_labels)
 
 
-def test_orthogonal_alignment():
-    random_seed = 483
-    np.random.seed(random_seed)
-    embedding_100_4d = np.random.uniform(0, 1, (5000, 4))
+@pytest.mark.parametrize("seed", [483, 425, 166, 672, 123])
+def test_orthogonal_alignment(seed):
+    np.random.seed(seed)
+    embedding_100_4d = np.random.uniform(0, 1, (1000, 4))
     orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4,
-                                                    random_state=random_seed)
+                                                    random_state=seed)
     labels_100_1d = np.random.uniform(0, 1, (1000, 1))
 
     alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment()
@@ -175,14 +175,14 @@ def test_orthogonal_alignment():
                                                           orthogonal_matrix),
                                                       ref_label=labels_100_1d,
                                                       label=labels_100_1d)
-    assert np.allclose(aligned_embedding, embedding_100_4d)
+    assert np.allclose(aligned_embedding, embedding_100_4d, atol = 0.03)
 
     # and without labels
     aligned_embedding = alignment_model.fit_transform(ref_data=embedding_100_4d,
                                                       data=np.dot(
                                                           embedding_100_4d,
                                                           orthogonal_matrix))
-    assert np.allclose(aligned_embedding, embedding_100_4d)
+    assert np.allclose(aligned_embedding, embedding_100_4d, atol = 0.03)
 
 
 def _initialize_embedding_ensembling_data():

--- a/tests/test_data_helper.py
+++ b/tests/test_data_helper.py
@@ -123,12 +123,12 @@ def test_orthogonal_alignment_shapes(ref_data, data, ref_labels, labels):
     assert _does_shape_match(data, aligned_embedding)
 
     # Test with non-default parameters
-    alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment(
-        top_k=10)
+    alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment(top_k=10)
 
     aligned_embedding = alignment_model.fit_transform(ref_data, data,
                                                       ref_labels, labels)
-    assert _does_shape_match(data, aligned_embedding), (data.shape, aligned_embedding.shape)
+    assert _does_shape_match(data, aligned_embedding), (data.shape,
+                                                        aligned_embedding.shape)
 
 
 @pytest.mark.parametrize("ref_data,data,ref_labels,labels,match",
@@ -156,16 +156,14 @@ def test_orthogonal_alignment_without_labels():
     aligned_embedding_without_labels = alignment_model.transform(
         embedding_100_4d_2)
 
-    assert np.allclose(aligned_embedding,
-                       aligned_embedding_without_labels)
+    assert np.allclose(aligned_embedding, aligned_embedding_without_labels)
 
 
 @pytest.mark.parametrize("seed", [483, 425, 166, 672, 123])
 def test_orthogonal_alignment(seed):
     np.random.seed(seed)
     embedding_100_4d = np.random.uniform(0, 1, (1000, 4))
-    orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4,
-                                                    random_state=seed)
+    orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4, random_state=seed)
     labels_100_1d = np.random.uniform(0, 1, (1000, 1))
 
     alignment_model = cebra_data_helper.OrthogonalProcrustesAlignment()
@@ -175,14 +173,14 @@ def test_orthogonal_alignment(seed):
                                                           orthogonal_matrix),
                                                       ref_label=labels_100_1d,
                                                       label=labels_100_1d)
-    assert np.allclose(aligned_embedding, embedding_100_4d, atol = 0.03)
+    assert np.allclose(aligned_embedding, embedding_100_4d, atol=0.03)
 
     # and without labels
     aligned_embedding = alignment_model.fit_transform(ref_data=embedding_100_4d,
                                                       data=np.dot(
                                                           embedding_100_4d,
                                                           orthogonal_matrix))
-    assert np.allclose(aligned_embedding, embedding_100_4d, atol = 0.03)
+    assert np.allclose(aligned_embedding, embedding_100_4d, atol=0.03)
 
 
 def _initialize_embedding_ensembling_data():
@@ -276,8 +274,7 @@ def test_embeddings_ensembling_without_labels():
         embeddings=[embedding_100_4d, embedding_100_4d_2], labels=[None, None])
     joint_embedding_without_labels = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2])
-    assert np.allclose(joint_embedding,
-                       joint_embedding_without_labels)
+    assert np.allclose(joint_embedding, joint_embedding_without_labels)
 
 
 @pytest.mark.parametrize("embeddings,labels,n_jobs,match",
@@ -290,16 +287,15 @@ def test_invalid_embedding_ensembling(embeddings, labels, n_jobs, match):
             n_jobs=n_jobs,
         )
 
+
 @pytest.mark.parametrize("seed", [483, 426, 166, 674, 123])
 def test_embedding_ensembling(seed):
     np.random.seed(seed)
     embedding_100_4d = np.random.uniform(0, 1, (100, 4))
     labels_100_1d = np.random.uniform(0, 1, (100, 1))
-    orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4,
-                                                    random_state=seed)
+    orthogonal_matrix = scipy.stats.ortho_group.rvs(dim=4, random_state=seed)
     orthogonal_matrix_2 = scipy.stats.ortho_group.rvs(dim=4,
-                                                      random_state=seed +
-                                                      1)
+                                                      random_state=seed + 1)
 
     embedding_100_4d_2 = np.dot(embedding_100_4d, orthogonal_matrix)
     embedding_100_4d_3 = np.dot(embedding_100_4d, orthogonal_matrix_2)
@@ -309,11 +305,11 @@ def test_embedding_ensembling(seed):
     joint_embedding = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2, embedding_100_4d_3],
         labels=labels)
-    assert np.allclose(joint_embedding, embedding_100_4d, atol = 0.05)
+    assert np.allclose(joint_embedding, embedding_100_4d, atol=0.05)
 
     joint_embedding = cebra_data_helper.ensemble_embeddings(
         embeddings=[embedding_100_4d, embedding_100_4d_2, embedding_100_4d_3])
-    assert np.allclose(joint_embedding, embedding_100_4d, atol = 0.05)
+    assert np.allclose(joint_embedding, embedding_100_4d, atol=0.05)
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
Multiple tests failed internally and on this repo (e.g., in #20 , #25, #26) due to a numerical issue in `OrthogonalProcrustesAlignment` when a too small value for `subsample` is used.

This PR fixes this by setting the default to `None`, which means that all points available in the embedding are used for alignment. This is the numerically best option. In other cases, warnings are emitted, when e.g. the values of `subsample` is smaller than the number of points in the dataset, or when the number of `subsample` is smaller than 1000 (a reasonable default).

This PR also improves the tests, and removes the `atol` value of several tests, or at least decreases it slightly to avoid false negatives in the future.

---

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/647
Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/645
Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/644