### PR TITLE
Fix action workflow definitions for external contributors

### DIFF
--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -8,7 +8,7 @@ name: PR Status
 # opens a PR.
 # IMPORTANT: DO NOT EXPOSE REPOSITORY SECRETS WITHIN THIS PR!
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main 
       - public

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -3,17 +3,20 @@ name: PR Status
 # Apache 2.0 licensed
 
 
+# NOTE(stes): Use pull_request_target instead of pull_request to allow
+# to post comments on the current PR, even when an external contributor
+# opens a PR.
+# IMPORTANT: DO NOT EXPOSE REPOSITORY SECRETS WITHIN THIS PR!
 on:
-  # NOTE(stes): Use pull_request_target instead of pull_request to allow
-  # to post comments on the current PR, even when an external contributor
-  # opens a PR.
-  # IMPORTANT: DO NOT EXPOSE REPOSITORY SECRETS WITHIN THIS PR!
   pull_request_target:
     branches:
       - main 
       - public
       - dev
-    
+
+permissions: 
+  pull-requests: write 
+
 jobs:
   documentation-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -4,7 +4,11 @@ name: PR Status
 
 
 on:
-  pull_request:
+  # NOTE(stes): Use pull_request_target instead of pull_request to allow
+  # to post comments on the current PR, even when an external contributor
+  # opens a PR.
+  # IMPORTANT: DO NOT EXPOSE REPOSITORY SECRETS WITHIN THIS PR!
+  pull_request_target:
     branches:
       - main 
       - public

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,6 @@ jobs:
           repository: AdaptiveMotorControlLab/cebra-figures
           path: docs/source/cebra-figures
           ref: main
-          token: ${{ secrets.GH_PAT_FIGURES }}
 
       - name: Checkout assets
         uses: actions/checkout@v3
@@ -39,7 +38,6 @@ jobs:
           repository: AdaptiveMotorControlLab/cebra-assets
           path: assets
           ref: main
-          token: ${{ secrets.GH_PAT_FIGURES }}
 
       - name: Add assets to repo
         run: |
@@ -52,7 +50,6 @@ jobs:
           repository: AdaptiveMotorControlLab/cebra-demos
           path: docs/source/demo_notebooks
           ref: main
-          token: ${{ secrets.GH_PAT_FIGURES }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -73,18 +70,32 @@ jobs:
           export SPHINXOPTS="-W --keep-going -n"
           make docs
 
-      - name: Deploy docs (staging)
-        uses: cpina/github-action-push-to-another-repository@main
-        if: github.ref != 'refs/heads/main'
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GH_PAT_WEBSITE }}
-        with:
-          source-directory: 'docs/page'
-          destination-github-username: 'stes'
-          destination-repository-name: 'cebra-ai'
-          user-name: stes
-          user-email: steffen@bethgelab.org
-          target-branch: staging
+      # NOTE(stes): To avoid issues as observed in 
+      # https://github.com/AdaptiveMotorControlLab/CEBRA/pull/20, we modified
+      # this workflow to not rely on PATs. All repos except for the website
+      # repo are public and only read access is required, so we simply removed
+      # the tokens from the checkout actions.
+      #  
+      # For pushing the docs, I temporarily disabled the staging repo, which
+      # does not add anything informative to the contributor anyways, as it just
+      # tests whether or not docs can be pushed (the staging branch is not deployed).
+      #
+      # The production branch will be built after the PR is merged to main.
+      #
+      # Commented code for staging branch:
+
+      #- name: Deploy docs (staging)
+      #  uses: cpina/github-action-push-to-another-repository@main
+      #  if: github.ref != 'refs/heads/main'
+      #  env:
+      #    API_TOKEN_GITHUB: ${{ secrets.GH_PAT_WEBSITE }}
+      #  with:
+      #    source-directory: 'docs/page'
+      #    destination-github-username: 'stes'
+      #    destination-repository-name: 'cebra-ai'
+      #    user-name: stes
+      #    user-email: steffen@bethgelab.org
+      #    target-branch: staging
 
       - name: Deploy docs (production)
         uses: cpina/github-action-push-to-another-repository@main


### PR DESCRIPTION
- The documentation status workflow needs to be updated to the `pull_request_target` as it uses the `GITHUB_TOKEN` to run.
- For the docs workflow, since all repos are public, we removed the token in the checkout action which allows external contributors to run this workflow.

Close #32 