### PR TITLE
saving and loading models (sklearn API)

### DIFF
--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -1288,7 +1288,7 @@ class CEBRA(BaseEstimator, TransformerMixin):
 
         """    
         if backend == "torch":
-            model = torch.load(filename, **kwargs)
+            cebra_ = torch.load(filename, **kwargs)
             if not isinstance(model, cls):
                 raise RuntimeError("Model loaded from file is not compatible with "
                                     "the current CEBRA version.")

--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -1206,12 +1206,12 @@ class CEBRA(BaseEstimator, TransformerMixin):
                     key: value for key, value in self.__dict__.items()
                      if key not in ['self']
                     }
-            warnings.warn("CEBRA object is not fitted. Are you sure you want to save it?")
+            raise ValueError("CEBRA object is not fitted. Saving it is not possible.")
 
         return state
 
 
-    def save(self, filename: str, backend: Literal["torch"] = "sklearn"):
+    def save(self, filename: str, backend: str = "torch"):
         """Save the model to disk.
 
         Args:
@@ -1312,29 +1312,17 @@ class CEBRA(BaseEstimator, TransformerMixin):
                         num_output=state["output_dimension"],
                     ).to(state['device_'])
 
-                else:
-                    pass
-                    #model = nn.ModuleList([
-                    #    cebra.models.init(
-                    #        state["model_architecture"],
-                    #        num_neurons=state["n_features_in_"],
-                    #        num_units=state["num_hidden_units"],
-                    #        num_output=state["output_dimension"],
-                    #    ) for dataset in dataset.iter_sessions()
-                    #]).to(state['device_'])    
-                     
+                elif isinstance(cebra_.num_sessions_, int):
                     
-                    #model = nn.ModuleList([
-                    #cebra.models.init(
-                    #self.model_architecture,
-                    #num_neurons=dataset.input_dimension,
-                    #num_units=self.num_hidden_units,
-                    #num_output=self.output_dimension,
-                    #) for dataset in dataset.iter_sessions()
-                    #    ]).to(self.device_)
-
-                    
-                
+                    model = nn.ModuleList([
+                        cebra.models.init(
+                            state["model_architecture"],
+                            num_neurons= n_features,
+                            num_units=state["num_hidden_units"],
+                            num_output=state["output_dimension"],
+                        ) for n_features in state["n_features_in_"]
+                    ]).to(state['device_'])    
+              
                 criterion  = cebra_._prepare_criterion()
                 criterion.to(state['device_'])
 

--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -1289,7 +1289,7 @@ class CEBRA(BaseEstimator, TransformerMixin):
         """    
         if backend == "torch":
             cebra_ = torch.load(filename, **kwargs)
-            if not isinstance(model, cls):
+            if not isinstance(cebra_, cls):
                 raise RuntimeError("Model loaded from file is not compatible with "
                                     "the current CEBRA version.")
 

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -851,4 +851,4 @@ def test_save_and_load_singlesession_sklearn_backend(action):
 # multiple model architectures -> specially the ones using @parametrize
 # temperature: auto vs fixed, make sure that we keep 
 # behavior vs time contrastive
-# TODO: now the solvername is added to the model but shouldnt!
+# TODO: now the solvername is added to the model but shouldn't!

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -810,3 +810,14 @@ def test_save_and_load(action):
         original_model.save(savefile.name)
         loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name)
     _assert_equal(original_model, loaded_model)
+
+
+def test_save_singlesession_model():
+    pass
+
+def test_save_multisession_model():
+    pass
+
+def test_save_singlesession_fitted_model():
+    pass
+

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -801,7 +801,7 @@ def _assert_equal(original_model, loaded_model):
 
 
 @pytest.mark.parametrize("action", _iterate_actions())
-def test_save_and_load(action):
+def test_save_and_load_torch_backend(action):
     model_architecture = "offset10-model"
     original_model = cebra_sklearn_cebra.CEBRA(
         model_architecture=model_architecture, max_iterations=5)
@@ -811,37 +811,44 @@ def test_save_and_load(action):
         loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name)
     _assert_equal(original_model, loaded_model)
 
-
-def test_save_singlesession_model():
-    data = np.random.uniform(0, 1, (1000, 4))
-
+@pytest.mark.parametrize("action", _iterate_actions())
+def test_save_and_load_singlesession_sklearn_backend(action):
+    #data = np.random.uniform(0, 1, (1000, 1)) #TODO: only works if num dim = 1 because _assert equal X = (100, 1)
     model_architecture = "offset10-model"
-
     original_model = cebra_sklearn_cebra.CEBRA(
         model_architecture=model_architecture, max_iterations=5)
     
-
-    original_model.fit(data)
-
+    original_model = action(original_model)
     with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as savefile:
         original_model.save(savefile.name, backend = "sklearn")
         loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name, "sklearn")
+    
     _assert_equal(original_model, loaded_model)
 
+#@pytest.mark.parametrize("action", _iterate_actions())
+#
+#def test_save_and_load_multisession_sklearn_backend():
+#    X = np.random.uniform(0, 1, (1000, 4)) #TODO: only works if num dim = 1 because _assert equal X = (100, 1)
+#    model_architecture = "offset10-model"
+#    original_model = cebra_sklearn_cebra.CEBRA(
+#        model_architecture=model_architecture, batch_size=512, max_iterations=5)
+#    
+#    original_model.fit([X, X], [X, X])
+#    with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as savefile:
+#        original_model.save(savefile.name, backend = "sklearn")
+#        loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name, "sklearn")
+#    
+#    _assert_equal(original_model, loaded_model)
 
-def test_save_multisession_model():
-    pass
-
-def test_save_singlesession_fitted_model():
-    pass
 
 
 # THINGS TO CHECK
-# device of saved and loaded models are the same
+# device of saved and loaded models are the same: i thhink this is checked already
 # it contains the same number of methods/attributes e.g. list(set(dir(saved_model)) - set(dir(loaded_model)))
+
 # you can train a model after loading it if it has been trained before / fitted vs unfitted models
 # that it works both for single session and for multisession
 # multiple model architectures -> specially the ones using @parametrize
 # temperature: auto vs fixed, make sure that we keep 
 # behavior vs time contrastive
-# ... 
+# TODO: now the solvername is added to the model but shouldnt!

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -813,7 +813,21 @@ def test_save_and_load(action):
 
 
 def test_save_singlesession_model():
-    pass
+    data = np.random.uniform(0, 1, (1000, 4))
+
+    model_architecture = "offset10-model"
+
+    original_model = cebra_sklearn_cebra.CEBRA(
+        model_architecture=model_architecture, max_iterations=5)
+    
+
+    original_model.fit(data)
+
+    with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as savefile:
+        original_model.save(savefile.name, backend = "sklearn")
+        loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name, "sklearn")
+    _assert_equal(original_model, loaded_model)
+
 
 def test_save_multisession_model():
     pass
@@ -821,3 +835,13 @@ def test_save_multisession_model():
 def test_save_singlesession_fitted_model():
     pass
 
+
+# THINGS TO CHECK
+# device of saved and loaded models are the same
+# it contains the same number of methods/attributes e.g. list(set(dir(saved_model)) - set(dir(loaded_model)))
+# you can train a model after loading it if it has been trained before / fitted vs unfitted models
+# that it works both for single session and for multisession
+# multiple model architectures -> specially the ones using @parametrize
+# temperature: auto vs fixed, make sure that we keep 
+# behavior vs time contrastive
+# ... 

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -778,6 +778,9 @@ def _assert_same_state_dict(first, second):
 
 def _assert_equal(original_model, loaded_model):
     assert original_model.get_params() == loaded_model.get_params()
+    assert original_model.device == loaded_model.device
+    assert next(original_model.parameters()).device == next(loaded_model.parameters()).device
+
 
     def check_fitted(model):
         """Check if a model is fitted.
@@ -799,56 +802,25 @@ def _assert_equal(original_model, loaded_model):
         assert np.allclose(loaded_model.transform(X),
                            original_model.transform(X))
 
-
-@pytest.mark.parametrize("action", _iterate_actions())
-def test_save_and_load_torch_backend(action):
-    model_architecture = "offset10-model"
-    original_model = cebra_sklearn_cebra.CEBRA(
-        model_architecture=model_architecture, max_iterations=5)
-    original_model = action(original_model)
-    with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as savefile:
-        original_model.save(savefile.name)
-        loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name)
-    _assert_equal(original_model, loaded_model)
-
 @pytest.mark.parametrize("action", _iterate_actions())
 def test_save_and_load_singlesession_sklearn_backend(action):
-    #data = np.random.uniform(0, 1, (1000, 1)) #TODO: only works if num dim = 1 because _assert equal X = (100, 1)
     model_architecture = "offset10-model"
     original_model = cebra_sklearn_cebra.CEBRA(
-        model_architecture=model_architecture, max_iterations=5)
+        model_architecture=model_architecture, max_iterations=5, batch_size=100)
     
     original_model = action(original_model)
     with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as savefile:
-        original_model.save(savefile.name, backend = "sklearn")
-        loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name, "sklearn")
-    
-    _assert_equal(original_model, loaded_model)
-
-#@pytest.mark.parametrize("action", _iterate_actions())
-#
-#def test_save_and_load_multisession_sklearn_backend():
-#    X = np.random.uniform(0, 1, (1000, 4)) #TODO: only works if num dim = 1 because _assert equal X = (100, 1)
-#    model_architecture = "offset10-model"
-#    original_model = cebra_sklearn_cebra.CEBRA(
-#        model_architecture=model_architecture, batch_size=512, max_iterations=5)
-#    
-#    original_model.fit([X, X], [X, X])
-#    with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as savefile:
-#        original_model.save(savefile.name, backend = "sklearn")
-#        loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name, "sklearn")
-#    
-#    _assert_equal(original_model, loaded_model)
-
+        if action.__name__ == "do_nothing":
+            with pytest.raises(ValueError):
+                original_model.save(savefile.name, backend = "sklearn")
+        else:
+            original_model.save(savefile.name, backend = "sklearn")
+            loaded_model = cebra_sklearn_cebra.CEBRA.load(savefile.name, "sklearn")
+            _assert_equal(original_model, loaded_model)
 
 
 # THINGS TO CHECK
-# device of saved and loaded models are the same: i thhink this is checked already
-# it contains the same number of methods/attributes e.g. list(set(dir(saved_model)) - set(dir(loaded_model)))
-
 # you can train a model after loading it if it has been trained before / fitted vs unfitted models
-# that it works both for single session and for multisession
 # multiple model architectures -> specially the ones using @parametrize
-# temperature: auto vs fixed, make sure that we keep 
+# temperature: auto vs fixed, make sure that we keep the parameters.
 # behavior vs time contrastive
-# TODO: now the solvername is added to the model but shouldn't!


### PR DESCRIPTION
Improve model saving in the sklearn API to ensure future compatibility and safety. Currently, we save the entire object using `torch.save`, which may cause issues with different CEBRA versions. This pull request (PR) tackles this problem by suggesting a solution that involves saving only the model weights and all the arguments used, allowing for complete reconstruction of the CEBRA object at loading time.

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/643

