### PR TITLE
Automatically download the rat-hippocampus dataset

### DIFF
--- a/cebra/data/assets.py
+++ b/cebra/data/assets.py
@@ -27,8 +27,10 @@ def download_file_with_progress_bar(url: str,
                                     location: str,
                                     file_name: str,
                                     retry_count: int = 0) -> Optional[str]:
-    """
-    Downloads a file from the given URL with a progress bar and performs checksum verification.
+    """Download a file from the given URL.
+    
+    During download, progress is reported using a progress bar. The downloaded
+    file's checksum is compared to the provided ``expected_checksum``.
 
     Args:
         url: The URL to download the file from.
@@ -41,7 +43,7 @@ def download_file_with_progress_bar(url: str,
         The path of the downloaded file if the download is successful, None otherwise.
 
     Raises:
-        RuntimeError: If the maximum retry count is exceeded.
+        RuntimeError: If the maximum ``retry count`` is exceeded.
     """
 
     # Check if the file already exists in the location
@@ -113,14 +115,13 @@ def download_file_with_progress_bar(url: str,
 
 
 def calculate_checksum(file_path: str) -> str:
-    """
-    Calculates the MD5 checksum of a file.
+    """Calculate the MD5 checksum of a file.
 
     Args:
         file_path: The path to the file.
 
     Returns:
-        str: The MD5 checksum of the file.
+        The MD5 checksum of the file.
     """
     checksum = hashlib.md5()
     with open(file_path, "rb") as file:

--- a/cebra/data/assets.py
+++ b/cebra/data/assets.py
@@ -10,17 +10,23 @@
 # https://github.com/AdaptiveMotorControlLab/CEBRA/LICENSE.md
 #
 
-import requests
-import os
-import tqdm
-import re
 import hashlib
+import os
+import re
 import warnings
 from typing import Optional
 
+import requests
+import tqdm
+
 _MAX_RETRY_COUNT = 2
 
-def download_file_with_progress_bar(url: str, expected_checksum: str, location: str, file_name: str, retry_count: int = 0) -> Optional[str]:
+
+def download_file_with_progress_bar(url: str,
+                                    expected_checksum: str,
+                                    location: str,
+                                    file_name: str,
+                                    retry_count: int = 0) -> Optional[str]:
     """
     Downloads a file from the given URL with a progress bar and performs checksum verification.
 
@@ -44,26 +50,33 @@ def download_file_with_progress_bar(url: str, expected_checksum: str, location: 
         existing_checksum = calculate_checksum(file_path)
         if existing_checksum == expected_checksum:
             return file_path
-    
-    if retry_count >= _MAX_RETRY_COUNT:
-        raise RuntimeError(f"Exceeded maximum retry count ({_MAX_RETRY_COUNT}). "
-                           f"Unable to download the file from {url}")
 
-    
+    if retry_count >= _MAX_RETRY_COUNT:
+        raise RuntimeError(
+            f"Exceeded maximum retry count ({_MAX_RETRY_COUNT}). "
+            f"Unable to download the file from {url}")
+
     response = requests.get(url, stream=True)
 
     # Check if the request was successful
     if response.status_code != 200:
-        raise requests.HTTPError(f"Error occurred while downloading the file. Response code: {response.status_code}")
+        raise requests.HTTPError(
+            f"Error occurred while downloading the file. Response code: {response.status_code}"
+        )
 
     # Check if the response headers contain the 'Content-Disposition' header
     if 'Content-Disposition' not in response.headers:
-        raise ValueError("Unable to determine the filename. 'Content-Disposition' header not found.")
+        raise ValueError(
+            "Unable to determine the filename. 'Content-Disposition' header not found."
+        )
 
     # Extract the filename from the 'Content-Disposition' header
-    filename_match = re.search(r'filename="(.+)"', response.headers.get("Content-Disposition"))
+    filename_match = re.search(r'filename="(.+)"',
+                               response.headers.get("Content-Disposition"))
     if not filename_match:
-        raise ValueError("Unable to determine the filename from the 'Content-Disposition' header.")
+        raise ValueError(
+            "Unable to determine the filename from the 'Content-Disposition' header."
+        )
 
     # Create the directory and any necessary parent directories
     os.makedirs(location, exist_ok=True)
@@ -75,10 +88,12 @@ def download_file_with_progress_bar(url: str, expected_checksum: str, location: 
     checksum = hashlib.md5()  # create checksum
 
     with open(file_path, "wb") as file:
-        with tqdm.tqdm(total=total_size, unit="B", unit_scale=True) as progress_bar:
+        with tqdm.tqdm(total=total_size, unit="B",
+                       unit_scale=True) as progress_bar:
             for data in response.iter_content(chunk_size=1024):
                 file.write(data)
-                checksum.update(data)  # Update the checksum with the downloaded data
+                checksum.update(
+                    data)  # Update the checksum with the downloaded data
                 progress_bar.update(len(data))
 
     downloaded_checksum = checksum.hexdigest()  # Get the checksum value
@@ -89,7 +104,9 @@ def download_file_with_progress_bar(url: str, expected_checksum: str, location: 
 
         # Retry download using a for loop
         for _ in range(retry_count + 1, _MAX_RETRY_COUNT + 1):
-            return download_file_with_progress_bar(url, expected_checksum, location, file_name, retry_count + 1)
+            return download_file_with_progress_bar(url, expected_checksum,
+                                                   location, file_name,
+                                                   retry_count + 1)
     else:
         print(f"Download complete. Dataset saved in '{file_path}'")
         return url

--- a/cebra/data/base.py
+++ b/cebra/data/base.py
@@ -19,6 +19,7 @@ import literate_dataclasses as dataclasses
 import numpy as np
 import torch
 
+import cebra.data.assets as cebra_data_assets
 import cebra.distributions
 import cebra.io
 from cebra.data.datatypes import Batch
@@ -41,9 +42,39 @@ class Dataset(abc.ABC, cebra.io.HasDevice):
             ``__getitem__`` and :py:meth:`expand_index` methods.
     """
 
-    def __init__(self, device="cpu"):
+    def __init__(self,
+                 device="cpu",
+                 download=False,
+                 data_url=None,
+                 data_checksum=None,
+                 location=None,
+                 file_name=None):
+
         self.offset: Offset = cebra.data.Offset(0, 1)
         super().__init__(device)
+
+        self.download = download
+        self.data_url = data_url
+        self.data_checksum = data_checksum
+        self.location = location
+        self.file_name = file_name
+
+        if self.download:
+            if self.data_url is None:
+                raise ValueError(
+                    "Missing data URL. Please provide the URL to download the data."
+                )
+
+            if self.data_checksum is None:
+                raise ValueError(
+                    "Missing data checksum. Please provide the checksum to verify the data integrity."
+                )
+
+            cebra_data_assets.download_file_with_progress_bar(
+                url=self.data_url,
+                expected_checksum=self.data_checksum,
+                location=self.location,
+                file_name=self.file_name)
 
     @property
     @abc.abstractmethod

--- a/cebra/datasets/assets.py
+++ b/cebra/datasets/assets.py
@@ -15,6 +15,7 @@ import os
 import tqdm
 import re
 import hashlib
+import warnings
 from typing import Optional
 
 _MAX_RETRY_COUNT = 2
@@ -82,9 +83,9 @@ def download_file_with_progress_bar(url: str, expected_checksum: str, location: 
 
     downloaded_checksum = checksum.hexdigest()  # Get the checksum value
     if downloaded_checksum != expected_checksum:
-        print(f"Checksum verification failed. Deleting {file_path}.")
+        warnings.warn(f"Checksum verification failed. Deleting '{file_path}'.")
         os.remove(file_path)
-        print("File deleted. Retrying download...")
+        warnings.warn("File deleted. Retrying download...")
 
         # Retry download using a for loop
         for _ in range(retry_count + 1, _MAX_RETRY_COUNT + 1):

--- a/cebra/datasets/assets.py
+++ b/cebra/datasets/assets.py
@@ -15,55 +15,101 @@ import os
 from tqdm import tqdm
 import re
 import hashlib
+from typing import Optional
 
-MAX_RETRY_COUNT = 2
+_MAX_RETRY_COUNT = 2
 
-def download_file_with_progress_bar(url, expected_checksum, location, retry_count=0):
+def download_file_with_progress_bar(url: str, expected_checksum: str, location: str, file_name: str, retry_count: int = 0) -> Optional[str]:
+    """
+    Downloads a file from the given URL with a progress bar and performs checksum verification.
 
-    if retry_count > MAX_RETRY_COUNT:
-        raise RuntimeError("Exceeded maximum retry count. Unable to download the file.")
+    Args:
+        url: The URL to download the file from.
+        expected_checksum: The expected checksum value of the downloaded file.
+        location: The directory where the file will be saved.
+        file_name: The name of the file.
+        retry_count: The number of retry attempts (default: 0).
+
+    Returns:
+        The path of the downloaded file if the download is successful, None otherwise.
+
+    Raises:
+        RuntimeError: If the maximum retry count is exceeded.
+    """
+
+    # Check if the file already exists in the location
+    file_path = os.path.join(location, file_name)
+    if os.path.exists(file_path):
+        existing_checksum = calculate_checksum(file_path)
+        if existing_checksum == expected_checksum:
+            return file_path
     
-    response = requests.get(url, stream=True)
+    if retry_count >= _MAX_RETRY_COUNT:
+        raise RuntimeError(f"Exceeded maximum retry count ({_MAX_RETRY_COUNT}). "
+                           f"Unable to download the file from {url}")
 
-    # Check if the request was successful
-    if response.status_code != 200:
-        print(f"Error occurred while downloading the file. Response code: {response.status_code}")
+    try:
+        response = requests.get(url, stream=True)
+
+        # Check if the request was successful
+        if response.status_code != 200:
+            raise requests.HTTPError(f"Error occurred while downloading the file. Response code: {response.status_code}")
+
+        # Check if the response headers contain the 'Content-Disposition' header
+        if 'Content-Disposition' not in response.headers:
+            raise ValueError("Unable to determine the filename. 'Content-Disposition' header not found.")
+
+        # Extract the filename from the 'Content-Disposition' header
+        filename_match = re.search(r'filename="(.+)"', response.headers.get("Content-Disposition"))
+        if not filename_match:
+            raise ValueError("Unable to determine the filename from the 'Content-Disposition' header.")
+
+        # Create the directory and any necessary parent directories
+        os.makedirs(location, exist_ok=True)
+
+        filename = filename_match.group(1)
+        file_path = os.path.join(location, filename)
+
+        total_size = int(response.headers.get("Content-Length", 0))
+        checksum = hashlib.md5()  # create checksum
+
+        with open(file_path, "wb") as file:
+            with tqdm(total=total_size, unit="B", unit_scale=True) as progress_bar:
+                for data in response.iter_content(chunk_size=1024):
+                    file.write(data)
+                    checksum.update(data)  # Update the checksum with the downloaded data
+                    progress_bar.update(len(data))
+
+        downloaded_checksum = checksum.hexdigest()  # Get the checksum value
+        if downloaded_checksum != expected_checksum:
+            print("Checksum verification failed. Deleting the file.")
+            os.remove(file_path)
+            print("File deleted. Retrying download...")
+
+            # Retry download using a for loop
+            for _ in range(retry_count + 1, _MAX_RETRY_COUNT + 1):
+                return download_file_with_progress_bar(url, location, expected_checksum, file_name, retry_count + 1)
+        else:
+            print(f"Download complete. Dataset saved in '{file_path}'")
+            return url
+
+    except Exception as e:
+        print(f"An exception occurred: {e}")
         return None
 
-    # Check if the response headers contain the 'Content-Disposition' header
-    if 'Content-Disposition' not in response.headers:
-        print("Unable to determine the filename. 'Content-Disposition' header not found.")
-        return None
 
-    # Extract the filename from the 'Content-Disposition' header
-    filename_match = re.search(r'filename="(.+)"', response.headers.get("Content-Disposition"))
-    if not filename_match:
-        print("Unable to determine the filename from the 'Content-Disposition' header.")
-        return None
+def calculate_checksum(file_path: str) -> str:
+    """
+    Calculates the MD5 checksum of a file.
 
-    # Create the directory and any necessary parent directories
-    os.makedirs(location, exist_ok=True)
-    
-    filename = filename_match.group(1)
-    file_path = os.path.join(location,filename)
+    Args:
+        file_path: The path to the file.
 
-    total_size = int(response.headers.get("Content-Length", 0))
-    checksum = hashlib.md5()  # create checksum
-
-    with open(file_path, "wb") as file:
-        with tqdm(total=total_size, unit="B", unit_scale=True) as progress_bar:
-            for data in response.iter_content(chunk_size=1024):
-                file.write(data)
-                checksum.update(data)  # Update the checksum with the downloaded data
-                progress_bar.update(len(data))
-    
-    downloaded_checksum = checksum.hexdigest()  # Get the checksum value
-    if downloaded_checksum != expected_checksum:
-        print("Checksum verification failed. Deleting the file.")
-        os.remove(file_path)
-        print("File deleted. Retrying download...")
-        return download_file_with_progress_bar(url, location, expected_checksum, retry_count + 1)
-
-
-    print(f"Download complete. Dataset saved in '{file_path}'")
-    return response
+    Returns:
+        str: The MD5 checksum of the file.
+    """
+    checksum = hashlib.md5()
+    with open(file_path, "rb") as file:
+        for chunk in iter(lambda: file.read(4096), b""):
+            checksum.update(chunk)
+    return checksum.hexdigest()

--- a/cebra/datasets/assets.py
+++ b/cebra/datasets/assets.py
@@ -1,0 +1,52 @@
+#
+# (c) All rights reserved. ECOLE POLYTECHNIQUE FÉDÉRALE DE LAUSANNE,
+# Switzerland, Laboratory of Prof. Mackenzie W. Mathis (UPMWMATHIS) and
+# original authors: Steffen Schneider, Jin H Lee, Mackenzie W Mathis. 2023.
+#
+# Source code:
+# https://github.com/AdaptiveMotorControlLab/CEBRA
+#
+# Please see LICENSE.md for the full license document:
+# https://github.com/AdaptiveMotorControlLab/CEBRA/LICENSE.md
+#
+
+import requests
+import os
+from tqdm import tqdm
+import re
+
+def download_file_with_progress_bar(url, location):
+    response = requests.get(url, stream=True)
+
+    # Check if the request was successful
+    if response.status_code != 200:
+        print(f"Error occurred while downloading the file. Response code: {response.status_code}")
+        return None
+
+    # Check if the response headers contain the 'Content-Disposition' header
+    if 'Content-Disposition' not in response.headers:
+        print("Unable to determine the filename. 'Content-Disposition' header not found.")
+        return None
+
+    # Extract the filename from the 'Content-Disposition' header
+    filename_match = re.search(r'filename="(.+)"', response.headers.get("Content-Disposition"))
+    if not filename_match:
+        print("Unable to determine the filename from the 'Content-Disposition' header.")
+        return None
+
+    # Create the directory and any necessary parent directories
+    os.makedirs(location, exist_ok=True)
+    
+    filename = filename_match.group(1)
+    file_path = os.path.join(location,filename)
+
+    total_size = int(response.headers.get("Content-Length", 0))
+
+    with open(file_path, "wb") as file:
+        with tqdm(total=total_size, unit="B", unit_scale=True) as progress_bar:
+            for data in response.iter_content(chunk_size=1024):
+                file.write(data)
+                progress_bar.update(len(data))
+
+    print(f"Download complete. Dataset saved in '{file_path}'")
+    return response

--- a/cebra/datasets/hippocampus.py
+++ b/cebra/datasets/hippocampus.py
@@ -79,18 +79,18 @@ class SingleRatDataset(cebra.data.SingleSessionDataset):
 
     """
 
-    def __init__(self, name="achilles", root=_DEFAULT_DATADIR):
+    def __init__(self, name="achilles", root=_DEFAULT_DATADIR, download = True):
         super().__init__()
 
         location = os.path.join(root, "rat_hippocampus")
         file_path = os.path.join(location, f"{name}.jl")
         
-        if not os.path.exists(file_path):
+        if download:
             download_file_with_progress_bar(url = rat_dataset_urls[name]["url"], 
                                             expected_checksum = rat_dataset_urls[name]["checksum"],
-                                            location = location)
+                                            location = location,
+                                            file_name = f"{name}.jl")
 
-        
         data = joblib.load(file_path)
         self.neural = torch.from_numpy(data["spikes"]).float()
         self.index = torch.from_numpy(data["position"]).float()

--- a/cebra/datasets/hippocampus.py
+++ b/cebra/datasets/hippocampus.py
@@ -36,8 +36,16 @@ from cebra.datasets import get_datapath
 from cebra.datasets import init
 from cebra.datasets import parametrize
 from cebra.datasets import register
+from cebra.datasets.assets import download_file_with_progress_bar
 
 _DEFAULT_DATADIR = get_datapath()
+
+rat_dataset_urls = {
+    "achilles": "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828",
+    "budy":     "https://figshare.com/ndownloader/files/40849460?private_link=9f91576cbbcc8b0d8828",
+    "cicero":   "https://figshare.com/ndownloader/files/40849457?private_link=9f91576cbbcc8b0d8828",
+    "gatsby":   "https://figshare.com/ndownloader/files/40849454?private_link=9f91576cbbcc8b0d8828"
+    }
 
 
 @register("rat-hippocampus-single")
@@ -56,10 +64,16 @@ class SingleRatDataset(cebra.data.SingleSessionDataset):
 
     """
 
-    def __init__(self, name="achilles", root=_DEFAULT_DATADIR):
+    def __init__(self, name="achilles", root=_DEFAULT_DATADIR, download_data = True):
         super().__init__()
-        path = os.path.join(root, f"rat_hippocampus/{name}.jl")
+
+        location = os.path.join(root, "rat_hippocampus")
+        if download_data:
+            download_file_with_progress_bar(rat_dataset_urls[name], location = location)
+
+        path = os.path.join(location, f"{name}.jl")
         data = joblib.load(path)
+        
         self.neural = torch.from_numpy(data["spikes"]).float()
         self.index = torch.from_numpy(data["position"]).float()
         self.name = name

--- a/cebra/datasets/hippocampus.py
+++ b/cebra/datasets/hippocampus.py
@@ -36,31 +36,35 @@ from cebra.datasets import get_datapath
 from cebra.datasets import init
 from cebra.datasets import parametrize
 from cebra.datasets import register
-from cebra.datasets.assets import download_file_with_progress_bar
 
 _DEFAULT_DATADIR = get_datapath()
 
 rat_dataset_urls = {
-
     "achilles": {
-                "url": "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828",
-                "checksum": "c52f9b55cbc23c66d57f3842214058b8"
-                },
-
-    "buddy":     {
-                "url":"https://figshare.com/ndownloader/files/40849460?private_link=9f91576cbbcc8b0d8828",
-                "checksum": "36341322907708c466871bf04bc133c2"
-                },   
-
-    "cicero":   {
-                "url": "https://figshare.com/ndownloader/files/40849457?private_link=9f91576cbbcc8b0d8828",
-                "checksum": "a83b02dbdc884fdd7e53df362499d42f"
-                },
-
-    "gatsby":   {"url": "https://figshare.com/ndownloader/files/40849454?private_link=9f91576cbbcc8b0d8828",
-                 "checksum": "2b889da48178b3155011c12555342813"
-                }
+        "url":
+            "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828",
+        "checksum":
+            "c52f9b55cbc23c66d57f3842214058b8"
+    },
+    "buddy": {
+        "url":
+            "https://figshare.com/ndownloader/files/40849460?private_link=9f91576cbbcc8b0d8828",
+        "checksum":
+            "36341322907708c466871bf04bc133c2"
+    },
+    "cicero": {
+        "url":
+            "https://figshare.com/ndownloader/files/40849457?private_link=9f91576cbbcc8b0d8828",
+        "checksum":
+            "a83b02dbdc884fdd7e53df362499d42f"
+    },
+    "gatsby": {
+        "url":
+            "https://figshare.com/ndownloader/files/40849454?private_link=9f91576cbbcc8b0d8828",
+        "checksum":
+            "2b889da48178b3155011c12555342813"
     }
+}
 
 
 @register("rat-hippocampus-single")
@@ -79,17 +83,15 @@ class SingleRatDataset(cebra.data.SingleSessionDataset):
 
     """
 
-    def __init__(self, name="achilles", root=_DEFAULT_DATADIR, download = True):
-        super().__init__()
-
+    def __init__(self, name="achilles", root=_DEFAULT_DATADIR, download=True):
         location = os.path.join(root, "rat_hippocampus")
         file_path = os.path.join(location, f"{name}.jl")
-        
-        if download:
-            download_file_with_progress_bar(url = rat_dataset_urls[name]["url"], 
-                                            expected_checksum = rat_dataset_urls[name]["checksum"],
-                                            location = location,
-                                            file_name = f"{name}.jl")
+
+        super().__init__(download=download,
+                         data_url=rat_dataset_urls[name]["url"],
+                         data_checksum=rat_dataset_urls[name]["checksum"],
+                         location=location,
+                         file_name=f"{name}.jl")
 
         data = joblib.load(file_path)
         self.neural = torch.from_numpy(data["spikes"]).float()
@@ -182,8 +184,8 @@ class SingleRatTrialSplitDataset(SingleRatDataset):
 
         """
 
-        direction_change_idx = np.where(
-            self.index[1:, 1] != self.index[:-1, 1])[0]
+        direction_change_idx = np.where(self.index[1:, 1] != self.index[:-1,
+                                                                        1])[0]
         trial_change_idx = np.append(
             np.insert(direction_change_idx[1::2], 0, 0), len(self.index))
         total_trials_num = len(trial_change_idx) - 1

--- a/cebra/datasets/hippocampus.py
+++ b/cebra/datasets/hippocampus.py
@@ -47,7 +47,7 @@ rat_dataset_urls = {
                 "checksum": "c52f9b55cbc23c66d57f3842214058b8"
                 },
 
-    "budy":     {
+    "buddy":     {
                 "url":"https://figshare.com/ndownloader/files/40849460?private_link=9f91576cbbcc8b0d8828",
                 "checksum": "36341322907708c466871bf04bc133c2"
                 },   

--- a/cebra/datasets/hippocampus.py
+++ b/cebra/datasets/hippocampus.py
@@ -41,10 +41,25 @@ from cebra.datasets.assets import download_file_with_progress_bar
 _DEFAULT_DATADIR = get_datapath()
 
 rat_dataset_urls = {
-    "achilles": "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828",
-    "budy":     "https://figshare.com/ndownloader/files/40849460?private_link=9f91576cbbcc8b0d8828",
-    "cicero":   "https://figshare.com/ndownloader/files/40849457?private_link=9f91576cbbcc8b0d8828",
-    "gatsby":   "https://figshare.com/ndownloader/files/40849454?private_link=9f91576cbbcc8b0d8828"
+
+    "achilles": {
+                "url": "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828",
+                "checksum": "c52f9b55cbc23c66d57f3842214058b8"
+                },
+
+    "budy":     {
+                "url":"https://figshare.com/ndownloader/files/40849460?private_link=9f91576cbbcc8b0d8828",
+                "checksum": "36341322907708c466871bf04bc133c2"
+                },   
+
+    "cicero":   {
+                "url": "https://figshare.com/ndownloader/files/40849457?private_link=9f91576cbbcc8b0d8828",
+                "checksum": "a83b02dbdc884fdd7e53df362499d42f"
+                },
+
+    "gatsby":   {"url": "https://figshare.com/ndownloader/files/40849454?private_link=9f91576cbbcc8b0d8828",
+                 "checksum": "2b889da48178b3155011c12555342813"
+                }
     }
 
 
@@ -64,16 +79,19 @@ class SingleRatDataset(cebra.data.SingleSessionDataset):
 
     """
 
-    def __init__(self, name="achilles", root=_DEFAULT_DATADIR, download_data = True):
+    def __init__(self, name="achilles", root=_DEFAULT_DATADIR):
         super().__init__()
 
         location = os.path.join(root, "rat_hippocampus")
-        if download_data:
-            download_file_with_progress_bar(rat_dataset_urls[name], location = location)
-
-        path = os.path.join(location, f"{name}.jl")
-        data = joblib.load(path)
+        file_path = os.path.join(location, f"{name}.jl")
         
+        if not os.path.exists(file_path):
+            download_file_with_progress_bar(url = rat_dataset_urls[name]["url"], 
+                                            expected_checksum = rat_dataset_urls[name]["checksum"],
+                                            location = location)
+
+        
+        data = joblib.load(file_path)
         self.neural = torch.from_numpy(data["spikes"]).float()
         self.index = torch.from_numpy(data["position"]).float()
         self.name = name

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -20,7 +20,7 @@ import torch
 
 import cebra.data
 import cebra.datasets
-import cebra.datasets.assets
+import cebra.data.assets as cebra_data_assets
 import cebra.registry
 from cebra.datasets import poisson
 
@@ -306,13 +306,13 @@ def parametrize_data(function):
 @parametrize_data
 def test_download_file_successful_download(filename, url, expected_checksum):
     with tempfile.TemporaryDirectory() as temp_dir:
-        cebra.datasets.assets.download_file_with_progress_bar(
+        cebra_data_assets.download_file_with_progress_bar(
             url=url,
             expected_checksum=expected_checksum,
             location=temp_dir,
             file_name=filename)
 
-        downloaded_checksum = cebra.datasets.assets.calculate_checksum(
+        downloaded_checksum = cebra_data_assets.calculate_checksum(
             os.path.join(temp_dir, filename))
         assert downloaded_checksum == expected_checksum
 
@@ -322,7 +322,7 @@ def test_download_file_wrong_checksum(filename, url, expected_checksum):
     wrong_checksum = ''.join(reversed(expected_checksum))
     with tempfile.TemporaryDirectory() as temp_dir:
         with pytest.raises(RuntimeError):
-            cebra.datasets.assets.download_file_with_progress_bar(
+            cebra_data_assets.download_file_with_progress_bar(
                 url=url,
                 expected_checksum=wrong_checksum,
                 location=temp_dir,
@@ -335,7 +335,7 @@ def test_download_file_wrong_url(filename, url, expected_checksum):
     wrong_url = "https://figshare.com/wrongurl"
     with tempfile.TemporaryDirectory() as temp_dir:
         with pytest.raises(requests.HTTPError):
-            cebra.datasets.assets.download_file_with_progress_bar(
+            cebra_data_assets.download_file_with_progress_bar(
                 url=wrong_url,
                 expected_checksum=expected_checksum,
                 location=temp_dir,
@@ -352,7 +352,7 @@ def test_download_file_wrong_content_disposition(filename, url,
             mock_response.headers = {}
 
             with pytest.raises(ValueError):
-                cebra.datasets.assets.download_file_with_progress_bar(
+                cebra_data_assets.download_file_with_progress_bar(
                     url=url,
                     expected_checksum=expected_checksum,
                     location=temp_dir,
@@ -360,7 +360,7 @@ def test_download_file_wrong_content_disposition(filename, url,
 
             mock_response.headers = {"Content-Disposition": "invalid_header"}
             with pytest.raises(ValueError):
-                cebra.datasets.assets.download_file_with_progress_bar(
+                cebra_data_assets.download_file_with_progress_bar(
                     url=url,
                     expected_checksum=expected_checksum,
                     location=temp_dir,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -279,3 +279,192 @@ def test_poisson_sampling(spike_rate, refractory_period):
         refractory_period=refractory_period)
 
     _assert_histograms_close(spike_counts.flatten().numpy(), reference_counts)
+
+
+### TEST DOWNLOAD FILE FUNCTION
+
+import os
+import hashlib
+import pytest
+from unittest.mock import patch
+from cebra.datasets.assets import download_file_with_progress_bar, calculate_checksum
+import tempfile
+import requests
+
+
+@pytest.fixture
+def temp_file(tmpdir):
+    file_path = os.path.join(tmpdir, "test_file")
+    with open(file_path, "w") as file:
+        file.write("Test file")
+    return file_path
+
+def test_calculate_checksum(temp_file):
+    expected = "098f6bcd4621d373cade4e832627b4f6" # GET THE EXPECTED CHECKSUM RIGHT
+    result = calculate_checksum(temp_file)
+    assert result == expected
+
+@pytest.mark.parametrize(
+    "name, url, expected_checksum",
+    [
+        ("achilles", "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828", "c52f9b55cbc23c66d57f3842214058b8"),
+    ]
+)
+def test_download_file_with_progress_bar_existing_file(name, url, expected_checksum):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Download the file to the temporary directory
+        filename =  f"{name}.jl"
+        file_path = os.path.join(temp_dir, filename)
+
+        download_file_with_progress_bar(url = url,expected_checksum= expected_checksum,
+                                        location= temp_dir,file_name= filename)
+
+        # Calculate the checksum of the downloaded file
+        downloaded_checksum = calculate_checksum(file_path)
+
+        # Compare the downloaded checksum with the expected checksum
+        assert downloaded_checksum == expected_checksum
+
+@pytest.mark.parametrize(
+    "name, url, expected_checksum",
+    [
+        ("achilles", "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828", "c52f9b55cbc23c66d57f3842214058b8"),
+    ]
+)
+def test_download_file_with_progress_bar_retry_exceeded(expected_checksum, url, name):
+     
+     wrong_checksum = ''.join(reversed(expected_checksum))
+
+     with tempfile.TemporaryDirectory() as temp_dir:
+        filename =  f"{name}.jl"
+        with pytest.raises(RuntimeError):
+            download_file_with_progress_bar(url, wrong_checksum, temp_dir, filename, retry_count=2)
+
+@pytest.mark.parametrize(
+    "name, url, expected_checksum",
+    [
+        ("achilles", "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828", "c52f9b55cbc23c66d57f3842214058b8"),
+    ]
+)
+def test_download_file_with_progress_bar_http_error(expected_checksum, name, url):
+    
+    wrong_url =  "https://figshare.com/wrongurl"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        filename =  f"{name}.jl"
+        with pytest.raises(requests.HTTPError):
+            download_file_with_progress_bar(wrong_url, expected_checksum, temp_dir, filename)
+
+
+
+@pytest.mark.parametrize(
+    "name, url, expected_checksum",
+    [
+        ("achilles", "https://figshare.com/ndownloader/files/40849463?private_link=9f91576cbbcc8b0d8828", "c52f9b55cbc23c66d57f3842214058b8"),
+    ]
+)
+def test_download_file_with_progress_bar_no_content_disposition(expected_checksum, url, name):
+    filename = f"{name}.jl"
+    print(filename)
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        with patch("requests.get") as mock_get:
+            mock_response = mock_get.return_value
+            mock_response.status_code = 200
+            mock_response.headers = {}
+
+            with pytest.raises(ValueError) as err:
+                download_file_with_progress_bar(url, expected_checksum, temp_dir, filename)
+
+            mock_response.headers = {"Content-Disposition": "invalid_header"}
+            with pytest.raises(ValueError) as err:
+                download_file_with_progress_bar(url, expected_checksum, temp_dir, filename)
+
+
+#def test_download_file_with_progress_bar_non_existing_file(expected_checksum, tmpdir):
+#    url = "https://example.com/file"
+#    location = str(tmpdir)
+#    file_name = "test_file"
+#
+#
+#
+#    downloaded_file = download_file_with_progress_bar(url, expected_checksum, location, file_name)
+#
+#    assert downloaded_file == os.path.join(location, file_name)
+#
+#
+#
+#
+#
+#
+#def test_download_file_with_progress_bar_invalid_content_disposition(expected_checksum, tmpdir):
+#    url = "https://example.com/file"
+#    location = str(tmpdir)
+#    file_name = "test_file"
+#
+#    with patch("requests.get") as mock_get:
+#        mock_response = mock_get.return_value
+#        mock_response.status_code = 200
+#        mock_response.headers = {"Content-Disposition": "invalid_header"}
+#
+#        with pytest.raises(ValueError):
+#            download_file_with_progress_bar(url, expected_checksum, location, file_name)
+#
+#
+#def test_download_file_with_progress_bar_successful_download(expected_checksum, tmpdir):
+#    url = "https://example.com/file"
+#    location = str(tmpdir)
+#    file_name = "test_file"
+#
+#    with patch("requests.get") as mock_get, \
+#         patch("tqdm.tqdm") as mock_tqdm, \
+#         patch("hashlib.md5") as mock_md5, \
+#         patch("builtins.open") as mock_open:
+#        mock_response = mock_get.return_value
+#        mock_response.status_code = 200
+#        mock_response.headers = {"Content-Disposition": 'filename="test_file"'}
+#        mock_response.iter_content.return_value = [b"test"]
+#
+#        mock_file = mock_open.return_value.__enter__.return_value
+#        mock_checksum = mock_md5.return_value
+#
+#        downloaded_file = download_file_with_progress_bar(url, expected_checksum, location, file_name)
+#
+#        mock_open.assert_called_with(os.path.join(location, file_name), "wb")
+#        mock_file.write.assert_called_with(b"test")
+#        mock_checksum.update.assert_called_with(b"test")
+#        mock_tqdm.assert_called_once()
+#        assert downloaded_file == url
+#
+#
+#def test_download_file_with_progress_bar_checksum_verification_failed(expected_checksum, tmpdir):
+#    url = "https://example.com/file"
+#    location = str(tmpdir)
+#    file_name = "test_file"
+#
+#    with patch("requests.get") as mock_get, \
+#         patch("tqdm.tqdm") as mock_tqdm, \
+#         patch("hashlib.md5") as mock_md5, \
+#         patch("builtins.open") as mock_open:
+#        mock_response = mock_get.return_value
+#        mock_response.status_code = 200
+#        mock_response.headers = {"Content-Disposition": 'filename="test_file"'}
+#        mock_response.iter_content.return_value = [b"test"]
+#
+#        mock_file = mock_open.return_value.__enter__.return_value
+#        mock_checksum = mock_md5.return_value
+#        mock_checksum.hexdigest.return_value = "invalid_checksum"
+#
+#        downloaded_file = download_file_with_progress_bar(url, expected_checksum, location, file_name)
+#
+#        mock_open.assert_called_with(os.path.join(location, file_name), "wb")
+#        mock_file.write.assert_called_with(b"test")
+#        mock_checksum.update.assert_called_with(b"test")
+#        mock_tqdm.assert_called_once()
+#        mock_open.assert_called_with(os.path.join(location, file_name), "wb")
+#        mock_file.write.assert_called_with(b"test")
+#        mock_checksum.update.assert_called_with(b"test")
+#        mock_tqdm.assert_called_once()
+#        mock_file.remove.assert_called_once()
+#        assert downloaded_file is None
+
+


### PR DESCRIPTION
This pull request allows automatic download of datasets e.g. `cebra.datasets.init('rat-hippocampus-single')`. We will support the rat dataset, the ALLEN dataset (neuropixel and calcium) and the monkey reaching dataset.

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/641