### PR TITLE
For docs build, limit scikit-learn version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ docs =
     matplotlib<=3.5.2
     pandas
     seaborn
+    scikit-learn<1.3
 demos =
     ipykernel
     jupyter


### PR DESCRIPTION
It seems like `scikit-learn` updated to 1.3.0 a few hours ago (https://pypi.org/project/scikit-learn/#history), but their index for doc build is not updated. This causes and issue that we tracked in https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/649.

I propose to temporarily pin sklearn below 1.3.0 *only for docs build*, which wont affect the main package, to fix this issue. Then, once the object files are updated and published by sklearn, we can unpin again. I will set a reminder to do that within a few weeks.

This will otherwise block merging a few PRs in the upcoming days.

---

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/649