### PR TITLE
Temporarily disable PR comment to report doc coverage

### DIFF
--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -66,14 +66,14 @@ jobs:
         RESULT="${RESULT//$'\r'/'%0D'}"
         echo "::set-output name=result::$RESULT"
       continue-on-error: true
-    - name: comment documentation result on PR
-      uses: thollander/actions-comment-pull-request@v1
-      with:
-        message: |
-          ## Docstring Coverage Report
-          ${{ steps.documentation.outputs.result }}
-        comment_includes: '## Docstring Coverage Report'
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #- name: comment documentation result on PR
+    #  uses: thollander/actions-comment-pull-request@v1
+    #  with:
+    #    message: |
+    #      ## Docstring Coverage Report
+    #      ${{ steps.documentation.outputs.result }}
+    #    comment_includes: '## Docstring Coverage Report'
+    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # following snippet borrowed from
     # https://stackoverflow.com/a/58003436
     # CC BY-SA 4.0, Peter Evans


### PR DESCRIPTION
To fix some issues we saw e.g. in #30 when running the doc coverage action (https://github.com/AdaptiveMotorControlLab/CEBRA/actions/runs/5415972675/jobs/9845039355?pr=30). I temporarily commented out the part of the workflow that posts the comment to the PR, the check itself is still run.