### PR TITLE
Add `...` pattern to copybutton config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ intersphinx_mapping = {
 }
 
 # Config is documented here: https://sphinx-copybutton.readthedocs.io/en/latest/
-copybutton_prompt_text = r">>> |\$ "
+copybutton_prompt_text = r">>> |\$ |\.\.\. "
 copybutton_prompt_is_regexp = True
 copybutton_only_copy_prompt_lines = True
 


### PR DESCRIPTION
Before, lines with `...` were not copied by using the copy button. This PR fixes that behavior by adapting the config for the sphinx copybutton package.

## Example

![image](https://github.com/AdaptiveMotorControlLab/CEBRA/assets/727984/56cc8db8-8755-4069-82e5-4551f0b87a01)


copied code:

``` python
import cebra.distributions.multisession as cebra_distributions_multisession
import cebra.integrations.sklearn.dataset as cebra_sklearn_dataset
import cebra.data
import torch
from torch import nn
# Multisession training: one model per dataset (different input dimensions)
session1 = torch.rand(100, 30)
session2 = torch.rand(100, 50)
index1 = torch.rand(100)
index2 = torch.rand(100)
num_features = 8
dataset = cebra.data.DatasetCollection(
              cebra_sklearn_dataset.SklearnDataset(session1, (index1, )),
              cebra_sklearn_dataset.SklearnDataset(session2, (index2, )))
model = nn.ModuleList([
               cebra.models.init(
                   name="offset1-model",
                   num_neurons=dataset.input_dimension,
                   num_units=32,
                   num_output=num_features,
               ) for dataset in dataset.iter_sessions()]).to("cpu")
sampler = cebra_distributions_multisession.MultisessionSampler(dataset, time_offset=10)
```

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/630
Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/652