### PR TITLE
Add NLB tools pypi package back as dataset dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,10 +41,7 @@ datasets =
     # cebra.datasets.allen
     h5py
     pandas
-    # NOTE(stes): The following dependency is used for the datasets in
-    # cebra.datasets.monkey_reaching. It needs to be manually installed,
-    # if needed.
-    # nlb_tools @ git+https://github.com/neurallatents/nlb_tools@065cb137ea3f9ecff4d237d2d404bf7a3c2890de
+    nlb_tools
     # additional data loading dependencies
     hdf5storage # for creating .mat files in new format
     openpyxl # for excel file format loading


### PR DESCRIPTION
As of march 24, the `nlb_tools` package [is available on pypi](https://github.com/neurallatents/nlb_tools/issues/9#issuecomment-1483240302). This PR adds the original dependency back in to avoid the manual installation.

For future reference, the original nlb_tools package used/recommended as "git+https://github.com/neurallatents/nlb_tools@065cb137ea3f9ecff4d237d2d404bf7a3c2890de"

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/665