### PR TITLE
Add Matplotlib ImportError when using compare_models()

### DIFF
--- a/cebra/helper.py
+++ b/cebra/helper.py
@@ -17,9 +17,8 @@ import tempfile
 import urllib
 import warnings
 import zipfile
-from typing import List, Union
-import pkg_resources
 from functools import wraps
+from typing import List, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -62,6 +61,7 @@ def download_file_from_zip_url(url, file="montblanc_tracks.h5"):
             except zipfile.error:
                 pass
     return pathlib.Path(foldername) / "data" / file
+
 
 def _is_mps_availabe(torch):
     available = False
@@ -123,21 +123,37 @@ def get_loader_options(dataset: "cebra.data.Dataset") -> List[str]:
         "Please update your imports.", DeprecationWarning)
     return cebra.data.helper.get_loader_options
 
-def requires_package_version(module, version):
+
+def requires_package_version(module, version: str):
+    """Decorator to require a minimum version of a package.
+
+    Args:
+        module: Module to be checked.
+        version: The minimum required version for the module.
+
+    Raises:
+        ImportError: If the specified ``module`` version is less than
+            the required ``version``.
+    """
+
     required_version = pkg_resources.parse_version(version)
 
     def _requires_package_version(function):
+
         @wraps(function)
         def wrapper(*args, patched_version=None, **kwargs):
             if patched_version != None:
-                installed_version = pkg_resources.parse_version(patched_version) # Use the patched version if provided
+                installed_version = pkg_resources.parse_version(
+                    patched_version)  # Use the patched version if provided
             else:
-                installed_version = pkg_resources.parse_version(module.__version__)
+                installed_version = pkg_resources.parse_version(
+                    module.__version__)
 
             if installed_version < required_version:
-                raise ImportError(f"The function '{function.__name__}' requires {module.__name__} "
-                                  f"version {required_version} or higher, but you have {installed_version}. "
-                                  f"Please upgrade {module.__name__}.")
+                raise ImportError(
+                    f"The function '{function.__name__}' requires {module.__name__} "
+                    f"version {required_version} or higher, but you have {installed_version}. "
+                    f"Please upgrade {module.__name__}.")
             return function(*args, **kwargs)
 
         return wrapper

--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -25,6 +25,7 @@ import numpy as np
 import numpy.typing as npt
 import sklearn.utils.validation
 import torch
+import pkg_resources
 
 from cebra import CEBRA
 
@@ -1185,6 +1186,12 @@ def compare_models(
         The axis of the generated plot. If no ``ax`` argument was specified, it will be created
         by the function and returned here.
     """
+
+    required_version = "3.5"
+    installed_version = pkg_resources.get_distribution("matplotlib").version
+    if installed_version < required_version:
+        raise ImportError(f"The function cebra.compare_models() requires matplotlib version {required_version} or higher.")
+
     if not isinstance(models, list):
         raise ValueError(f"Invalid list of models, got {type(models)}.")
     for model in models:

--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -1186,12 +1186,26 @@ def compare_models(
         The axis of the generated plot. If no ``ax`` argument was specified, it will be created
         by the function and returned here.
     """
+    # OPTION 1
     #note this is the min. required version for matplotlib
-    required_version = "3.5"
-    installed_version = pkg_resources.get_distribution("matplotlib").version
+    required_version = pkg_resources.parse_version("3.6")
+    installed_version = pkg_resources.parse_version(matplotlib.__version__)
+    
     if installed_version < required_version:
         raise ImportError(f"The function cebra.compare_models() requires matplotlib version {required_version} or higher.")
 
+    # OPTION 2
+    #note this is the min. required version for matplotlib
+    def versiontuple(v):
+        return tuple(map(int, (v.split("."))))
+    
+    required_version = versiontuple("3.6")
+    installed_version = versiontuple(matplotlib.__version__)
+    
+    if installed_version < required_version:
+        raise ImportError(f"The function cebra.compare_models() requires matplotlib"
+                           f"version {'.'.join(str(x) for x in required_version)} or higher.")
+    
     if not isinstance(models, list):
         raise ValueError(f"Invalid list of models, got {type(models)}.")
     for model in models:

--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -1186,7 +1186,7 @@ def compare_models(
         The axis of the generated plot. If no ``ax`` argument was specified, it will be created
         by the function and returned here.
     """
-
+    #note this is the min. required version for matplotlib
     required_version = "3.5"
     installed_version = pkg_resources.get_distribution("matplotlib").version
     if installed_version < required_version:

--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -25,7 +25,6 @@ import numpy as np
 import numpy.typing as npt
 import sklearn.utils.validation
 import torch
-import pkg_resources
 
 from cebra import CEBRA
 
@@ -1132,7 +1131,8 @@ def plot_consistency(
         dpi=dpi,
     ).plot(**kwargs)
 
-
+from cebra.helper import requires_package_version
+@requires_package_version(matplotlib, "3.6")
 def compare_models(
     models: List[CEBRA],
     labels: Optional[List[str]] = None,
@@ -1186,13 +1186,7 @@ def compare_models(
         The axis of the generated plot. If no ``ax`` argument was specified, it will be created
         by the function and returned here.
     """
-    
-    required_version = pkg_resources.parse_version("3.6") #note this is the min. required version for matplotlib
-    installed_version = pkg_resources.parse_version(matplotlib.__version__)
-    
-    if installed_version < required_version:
-        raise ImportError(f"The function cebra.compare_models() requires matplotlib version {required_version} or higher.")
-    
+
     if not isinstance(models, list):
         raise ValueError(f"Invalid list of models, got {type(models)}.")
     

--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -1131,7 +1131,10 @@ def plot_consistency(
         dpi=dpi,
     ).plot(**kwargs)
 
+
 from cebra.helper import requires_package_version
+
+
 @requires_package_version(matplotlib, "3.6")
 def compare_models(
     models: List[CEBRA],
@@ -1189,7 +1192,7 @@ def compare_models(
 
     if not isinstance(models, list):
         raise ValueError(f"Invalid list of models, got {type(models)}.")
-    
+
     for model in models:
         if not isinstance(model, CEBRA):
             raise ValueError(

--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -1186,28 +1186,16 @@ def compare_models(
         The axis of the generated plot. If no ``ax`` argument was specified, it will be created
         by the function and returned here.
     """
-    # OPTION 1
-    #note this is the min. required version for matplotlib
-    required_version = pkg_resources.parse_version("3.6")
+    
+    required_version = pkg_resources.parse_version("3.6") #note this is the min. required version for matplotlib
     installed_version = pkg_resources.parse_version(matplotlib.__version__)
     
     if installed_version < required_version:
         raise ImportError(f"The function cebra.compare_models() requires matplotlib version {required_version} or higher.")
-
-    # OPTION 2
-    #note this is the min. required version for matplotlib
-    def versiontuple(v):
-        return tuple(map(int, (v.split("."))))
-    
-    required_version = versiontuple("3.6")
-    installed_version = versiontuple(matplotlib.__version__)
-    
-    if installed_version < required_version:
-        raise ImportError(f"The function cebra.compare_models() requires matplotlib"
-                           f"version {'.'.join(str(x) for x in required_version)} or higher.")
     
     if not isinstance(models, list):
         raise ValueError(f"Invalid list of models, got {type(models)}.")
+    
     for model in models:
         if not isinstance(model, CEBRA):
             raise ValueError(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -152,19 +152,18 @@ def test_compare_models_with_different_versions(matplotlib_version):
     fitted_models = []
     for _ in range(n_models):
         fitted_models.append(
-            cebra_sklearn_cebra.CEBRA(max_iterations=10, batch_size=512).fit(X)
+            cebra_sklearn_cebra.CEBRA(max_iterations=10, batch_size=128).fit(X)
             )
+    
+    # minimum version of matplotlib 
+    minimum_version = "3.6"
     
     # Patch the matplotlib version
     matplotlib.__version__ = matplotlib_version
 
-    try:
-        cebra_plot.compare_models(models = fitted_models)
-    except ImportError as e:
-        pass  # Expected ImportError
-    else:
-        assert pkg_resources.parse_version(matplotlib_version) >= pkg_resources.parse_version("3.6")
-
+    if pkg_resources.parse_version(matplotlib_version) < pkg_resources.parse_version(minimum_version):
+        with pytest.raises(ImportError):
+            cebra_plot.compare_models(models=fitted_models)
 
 def test_compare_models():
     # example dataset

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -14,10 +14,10 @@ import copy
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import pkg_resources
 import pytest
 import torch
 from sklearn.exceptions import NotFittedError
-import pkg_resources
 
 import cebra.integrations.matplotlib as cebra_plot
 import cebra.integrations.sklearn.cebra as cebra_sklearn_cebra
@@ -143,7 +143,9 @@ def test_plot_loss():
     assert isinstance(ax, matplotlib.axes.Axes)
     plt.close()
 
-@pytest.mark.parametrize("matplotlib_version", ["3.3", "3.4.2", "3.5", "3.6", "3.7"] )
+
+@pytest.mark.parametrize("matplotlib_version",
+                         ["3.3", "3.4.2", "3.5", "3.6", "3.7"])
 def test_compare_models_with_different_versions(matplotlib_version):
     # example dataset
     X = np.random.uniform(0, 1, (1000, 2))
@@ -152,15 +154,17 @@ def test_compare_models_with_different_versions(matplotlib_version):
     fitted_models = []
     for _ in range(n_models):
         fitted_models.append(
-            cebra_sklearn_cebra.CEBRA(max_iterations=10, batch_size=128).fit(X)
-            )
-    
-    # minimum version of matplotlib 
+            cebra_sklearn_cebra.CEBRA(max_iterations=10, batch_size=128).fit(X))
+
+    # minimum version of matplotlib
     minimum_version = "3.6"
-    
-    if pkg_resources.parse_version(matplotlib_version) < pkg_resources.parse_version(minimum_version):
+
+    if pkg_resources.parse_version(
+            matplotlib_version) < pkg_resources.parse_version(minimum_version):
         with pytest.raises(ImportError):
-            cebra_plot.compare_models(models=fitted_models, patched_version = matplotlib_version)
+            cebra_plot.compare_models(models=fitted_models,
+                                      patched_version=matplotlib_version)
+
 
 def test_compare_models():
     # example dataset

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -158,12 +158,9 @@ def test_compare_models_with_different_versions(matplotlib_version):
     # minimum version of matplotlib 
     minimum_version = "3.6"
     
-    # Patch the matplotlib version
-    matplotlib.__version__ = matplotlib_version
-
     if pkg_resources.parse_version(matplotlib_version) < pkg_resources.parse_version(minimum_version):
         with pytest.raises(ImportError):
-            cebra_plot.compare_models(models=fitted_models)
+            cebra_plot.compare_models(models=fitted_models, patched_version = matplotlib_version)
 
 def test_compare_models():
     # example dataset

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 import torch
 from sklearn.exceptions import NotFittedError
+import pkg_resources
 
 import cebra.integrations.matplotlib as cebra_plot
 import cebra.integrations.sklearn.cebra as cebra_sklearn_cebra
@@ -142,11 +143,33 @@ def test_plot_loss():
     assert isinstance(ax, matplotlib.axes.Axes)
     plt.close()
 
+@pytest.mark.parametrize("matplotlib_version", ["3.3", "3.4.2", "3.5", "3.6", "3.7"] )
+def test_compare_models_with_different_versions(matplotlib_version):
+    # example dataset
+    X = np.random.uniform(0, 1, (1000, 2))
+    n_models = 2
+
+    fitted_models = []
+    for _ in range(n_models):
+        fitted_models.append(
+            cebra_sklearn_cebra.CEBRA(max_iterations=10, batch_size=512).fit(X)
+            )
+    
+    # Patch the matplotlib version
+    matplotlib.__version__ = matplotlib_version
+
+    try:
+        cebra_plot.compare_models(models = fitted_models)
+    except ImportError as e:
+        pass  # Expected ImportError
+    else:
+        assert pkg_resources.parse_version(matplotlib_version) >= pkg_resources.parse_version("3.6")
+
 
 def test_compare_models():
     # example dataset
-    X = np.random.uniform(0, 1, (1000, 50))
-    n_models = 10
+    X = np.random.uniform(0, 1, (100, 5))
+    n_models = 4
 
     fig = plt.figure(figsize=(5, 5))
     ax = fig.add_subplot()


### PR DESCRIPTION
This pull request introduces a custom decorator `@requires_package_version` enabling the specification of the required package version for a specific function. We use it to specify the version of `compare_models()` function since it requires Matplotlib version 3.6 or higher.

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/639
Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/580