### PR TITLE
Fix test failures due to http rate limit

### DIFF
--- a/cebra/helper.py
+++ b/cebra/helper.py
@@ -48,7 +48,7 @@ def download_file_from_url(url: str) -> str:
     return filename
 
 
-def download_file_from_zip_url(url, file="montblanc_tracks.h5"):
+def download_file_from_zip_url(url, *, file):
     """Directly extract files without writing the archive to disk."""
     with tempfile.TemporaryDirectory() as tf:
         foldername = tf

--- a/tests/test_dlc.py
+++ b/tests/test_dlc.py
@@ -169,7 +169,7 @@ def test_load_data_dlc_invalid_keypoints(filename, keypoints):
 ### multi-animals
 def test_multianimal_dlc_file():
     filename = cebra.helper.download_file_from_zip_url(
-        url=MULTISESSION_PRED_DLC_URL)
+        url=MULTISESSION_PRED_DLC_URL, file="montblanc_tracks.h5")
     with pytest.raises(NotImplementedError, match="Multi-animals.*"):
         _ = cebra_dlc.load_deeplabcut(filename)
 

--- a/tests/test_dlc.py
+++ b/tests/test_dlc.py
@@ -20,9 +20,19 @@ import cebra.integrations.deeplabcut as cebra_dlc
 from cebra import CEBRA
 from cebra import load_data
 
-ANNOTATED_DLC_URL = "https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/Reaching-Mackenzie-2018-08-30/labeled-data/reachingvideo1/CollectedData_Mackenzie.h5?raw=true"
+# NOTE(stes): The original data URL is
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/examples
+# /Reaching-Mackenzie-2018-08-30/labeled-data/reachingvideo1
+# /CollectedData_Mackenzie.h5?raw=true
+# which is replaced here due to rate limitations we observed in the past.
+ANNOTATED_DLC_URL = "https://figshare.com/ndownloader/files/42303564?private_link=b917317bfab725e0b207"
+
+# NOTE(stes): The original data URL is
+# https://github.com/DeepLabCut/UnitTestData/raw/main/data.zip")
+# which is replaced here due to rate limitations we observed in the past.
 MULTISESSION_PRED_DLC_URL = (
-    "https://github.com/DeepLabCut/UnitTestData/raw/main/data.zip")
+    "https://figshare.com/ndownloader/files/42303561?private_link=b917317bfab725e0b207"
+)
 
 MULTISESSION_PRED_KEYPOINTS = ["head", "tail"]
 ANNOTATED_KEYPOINTS = ["Hand", "Tongue"]
@@ -166,7 +176,7 @@ def test_multianimal_dlc_file():
 
 def test_multianimal_data_dlc_file():
     filename = cebra.helper.download_file_from_zip_url(
-        url=MULTISESSION_PRED_DLC_URL)
+        url=MULTISESSION_PRED_DLC_URL, file="montblanc_tracks.h5")
     with pytest.raises(NotImplementedError, match="Multi-animals.*"):
         _ = load_data(filename)
 


### PR DESCRIPTION
We observed a test failure in #59 , most likely due to rate limits when downloading raw data for testing from github. This PR replaces [some of the links](https://github.com/AdaptiveMotorControlLab/CEBRA/blob/a21ba0ec17a8c7cc67fc24187f119a52c4132cd0/tests/test_dlc.py#L23-L25) with references to [figshare](https://figshare.com/s/b917317bfab725e0b207) which is probably better suited to host the files.