### PR TITLE
Pin `tables` <= 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ dev =
     pytest-xdist
     pytest-timeout
     pytest-sphinx
-    tables
+    tables<=3.8
     licenseheaders
     # TODO(stes) Add back once upstream issue
     # https://github.com/PyCQA/docformatter/issues/119


### PR DESCRIPTION
`tables` made a really fresh release of 3.9.0 on Oct 5, and 3.9.1 on Oct 6, which breaks the current build. We'll restrict to the previous version and then further investigate the root issue.

See: https://pypi.org/project/tables/3.9.1/