### PR TITLE
Release v0.3.1rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN make dist
 FROM cebra-base
 
 # install the cebra wheel
-ENV WHEEL=cebra-0.3.0-py2.py3-none-any.whl
+ENV WHEEL=cebra-0.3.1rc1-py2.py3-none-any.whl
 WORKDIR /build
 COPY --from=wheel /build/dist/${WHEEL} .
 RUN pip install --no-cache-dir ${WHEEL}'[dev,integrations,datasets]'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CEBRA_VERSION=$(shell python3 -c "import cebra; print(cebra.__version__)")
+CEBRA_VERSION := 0.3.1rc1
 
 dist:
 	python3 -m pip install virtualenv
@@ -10,7 +10,7 @@ build: dist
 archlinux:
 	mkdir -p dist/arch
 	cp PKGBUILD dist/arch
-	cp dist/cebra-0.3.0.tar.gz dist/arch
+	cp dist/cebra-${CEBRA_VERSION}.tar.gz dist/arch
 	(cd dist/arch; makepkg --skipchecksums -f)
 
 # NOTE(stes): Ensure that no old tempfiles are present. Ideally, move this into

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Steffen Schneider <stes@hey.com>
 pkgname=python-cebra
 _pkgname=cebra
-pkgver=0.3.0
+pkgver=0.3.1rc1
 pkgrel=1
 pkgdesc="Consistent Embeddings of high-dimensional Recordings using Auxiliary variables"
 url="https://cebra.ai"

--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ It can jointly use behavioral and neural data in a hypothesis- or discovery-driv
   [Learnable latent embeddings for joint behavioral and neural analysis.](https://arxiv.org/abs/2204.00673)
   Steffen Schneider*, Jin Hwa Lee* and Mackenzie Weygandt Mathis
 
- # License
+# License
+
 -  CEBRA is released for academic use only (please read the license file). If this license is not appropriate for your application, please contact Prof. Mackenzie W. Mathis (mackenzie@post.harvard.edu) for a commercial use license.

--- a/cebra/__init__.py
+++ b/cebra/__init__.py
@@ -56,7 +56,7 @@ except (ImportError, NameError):
 
 import cebra.integrations.sklearn as sklearn
 
-__version__ = "0.3.0"
+__version__ = "0.3.1rc1"
 __all__ = ["CEBRA"]
 __allow_lazy_imports = False
 __lazy_imports = {}

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -15,7 +15,7 @@ pip uninstall -y cebra
 # Get version info after uninstalling --- this will automatically get the
 # most recent version based on the source code in the current directory.
 # $(tools/get_cebra_version.sh)
-VERSION=0.3.0
+VERSION=0.3.1rc1
 echo "Upgrading to CEBRA v${VERSION}"
 
 # Upgrade the build system (PEP517/518 compatible)

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Bump the CEBRA version to the specified value.
+# Edits all relevant files at once.
+# 
+# Usage:
+# tools/bump_version.sh 0.3.1rc1
+
+version=$1
+if [ -z ${version} ]; then
+    >&1 echo "Specify a version number."
+    >&1 echo "Usage:"
+    >&1 echo "tools/bump_version.sh <semantic version>"
+fi
+
+# python cebra version
+sed -i "s/__version__ = .*/__version__ = \"${version}\"/" \
+    cebra/__init__.py
+
+# reinstall script in root
+sed -i "s/VERSION=.*/VERSION=${version}/" \
+    reinstall.sh
+
+# Makefile
+sed -i "s/CEBRA_VERSION := .*/CEBRA_VERSION := ${version}/" \
+    Makefile
+
+# Arch linux PKGBUILD 
+sed -i "s/pkgver=.*/pkgver=${version}/" \
+    PKGBUILD 
+
+# Dockerfile
+sed -i "s/ENV WHEEL=cebra-.*\.whl/ENV WHEEL=cebra-${version}-py2.py3-none-any.whl/" \
+    Dockerfile 


### PR DESCRIPTION
This is the release PR for v0.3.1, the biggest change is the integration of various PRs for easier use of the plotly integration (#103 , #102 , #96 ).

I also added a tool for easier bumping the package version, as it is distributed to quite a few places in the codebase. This tool can be run as follows:

```
./tools/bump_version.sh 0.3.1rc1
```

Open TODOs:

- [x] merge https://github.com/AdaptiveMotorControlLab/CEBRA/pull/103


### Release checklist

- [x] Make sure all tests pass on the rc branch. Also make sure that the [milestone](https://github.com/stes/neural_cl/milestones) related to this release is fully done. Move issues that wont make it into the release to the next milestone, then close the milestone.
- [x] Head to [`cebra.__init__`](neural_cl/cebra_public/cebra/__init__.py) and make sure that the `__version__` is set correctly.
- [x] [Create a PR](https://github.com/stes/neural_cl/compare) between rc and `main`
- [x] Tag the PR with the `release` [label](https://github.com/stes/neural_cl/issues/labels).
- [x] A [github action will be run ](https://github.com/stes/neural_cl/blob/main/.github/workflows/internal-release.yml) -- if it doesnt start, try removing and re-adding the release label (step 4).
- [x] Carefully check that the release looks fine --- the version from the PR will be pushed to [`release-staging`](https://github.com/AdaptiveMotorControlLab/cebra-internal/tree/release-staging) and [`staging`](https://github.com/AdaptiveMotorControlLab/cebra-internal/tree/staging) in the [`cebra-internal`](https://github.com/AdaptiveMotorControlLab/cebra-internal) repo. *Note: If you update the PR, these version will not be automatically updated. Repeat step 4 or trigger a manual workflow run if you need to update the staging version*
- [ ] If all looks good, tests pass and the PR is reviewed, merge the PR **using rebase merging**.
- [ ] Delete the branch
- [ ] Checkout the updated `main` branch, `git tag v1.2.3` with the correct format (if alpha/beta tags are used in __version__, use `v1.2.3a4` or `v1.2.3b4`), and `git push v1.2.3` the tag.
- [ ] Pushing the tag will update the release in `cebra-internal`. The source tree will land on [`main`](https://github.com/AdaptiveMotorControlLab/cebra-internal), the pre-build wheel and source distribution on [`release`](https://github.com/AdaptiveMotorControlLab/cebra-internal/tree/release).