### PR TITLE
Fixed showlegend for plotly

### DIFF
--- a/cebra/integrations/plotly.py
+++ b/cebra/integrations/plotly.py
@@ -96,29 +96,37 @@ class _EmbeddingInteractivePlot(_EmbeddingPlot):
         """
 
         idx1, idx2, idx3 = self.idx_order
-        data = [
-            plotly.graph_objects.Scatter3d(
-                x=self.embedding[:, idx1],
-                y=self.embedding[:, idx2],
-                z=self.embedding[:, idx3],
-                mode="markers",
-                marker=dict(
-                    size=self.markersize,
-                    opacity=self.alpha,
-                    color=self.embedding_labels,
-                    colorscale=self.colorscale,
-                ),
+        unique_labels = set(self.embedding_labels)
+        data = []
+
+        for label in unique_labels:
+            filtered_idx = [i for i, x in enumerate(self.embedding_labels) if x == label]
+            data.append(
+                plotly.graph_objects.Scatter3d(
+                    x=self.embedding[filtered_idx, idx1],
+                    y=self.embedding[filtered_idx, idx2],
+                    z=self.embedding[filtered_idx, idx3],
+                    mode="markers",
+                    marker=dict(
+                        size=self.markersize,
+                        opacity=self.alpha,
+                        color=label, 
+                        colorscale=self.colorscale,
+                    ),
+                    name=str(label) 
+                )
             )
-        ]
+
         col = kwargs.get("col", None)
         row = kwargs.get("row", None)
         showlegend = kwargs.get("showlegend", False)
         template = kwargs.get("template", "plotly_white")
 
-        if col is None or row is None:
-            self.axis.add_trace(data[0])
-        else:
-            self.axis.add_trace(data[0], row=row, col=col)
+        for trace in data:
+            if col is None or row is None:
+                self.axis.add_trace(trace)
+            else:
+                self.axis.add_trace(trace, row=row, col=col)
 
         self.axis.update_layout(
             template=template,

--- a/cebra/integrations/plotly.py
+++ b/cebra/integrations/plotly.py
@@ -94,33 +94,45 @@ class _EmbeddingInteractivePlot(_EmbeddingPlot):
         Returns:
             The axis :py:meth:`plotly.graph_objs._figure.Figure` of the plot.
         """
-
-        idx1, idx2, idx3 = self.idx_order
-        unique_labels = set(self.embedding_labels)
-        data = []
-
-        for label in unique_labels:
-            filtered_idx = [i for i, x in enumerate(self.embedding_labels) if x == label]
-            data.append(
-                plotly.graph_objects.Scatter3d(
-                    x=self.embedding[filtered_idx, idx1],
-                    y=self.embedding[filtered_idx, idx2],
-                    z=self.embedding[filtered_idx, idx3],
-                    mode="markers",
-                    marker=dict(
-                        size=self.markersize,
-                        opacity=self.alpha,
-                        color=label, 
-                        colorscale=self.colorscale,
-                    ),
-                    name=str(label) 
-                )
-            )
-
+        showlegend = kwargs.get("showlegend", False)
+        discrete = kwargs.get("discrete", False)
         col = kwargs.get("col", None)
         row = kwargs.get("row", None)
-        showlegend = kwargs.get("showlegend", False)
         template = kwargs.get("template", "plotly_white")
+        data = []
+
+        if not discrete and showlegend:
+            raise ValueError("Cannot show legend with continious labels.")
+
+        idx1, idx2, idx3 = self.idx_order
+
+        if discrete:
+            unique_labels = np.unique(self.embedding_labels)
+        else:
+            unique_labels = [self.embedding_labels]
+
+        for label in unique_labels:
+            if discrete:
+                filtered_idx = [
+                    i for i, x in enumerate(self.embedding_labels) if x == label
+                ]
+            else:
+                filtered_idx = np.arange(self.embedding.shape[0])
+            data.append(
+                plotly.graph_objects.Scatter3d(x=self.embedding[filtered_idx,
+                                                                idx1],
+                                               y=self.embedding[filtered_idx,
+                                                                idx2],
+                                               z=self.embedding[filtered_idx,
+                                                                idx3],
+                                               mode="markers",
+                                               marker=dict(
+                                                   size=self.markersize,
+                                                   opacity=self.alpha,
+                                                   color=label,
+                                                   colorscale=self.colorscale,
+                                               ),
+                                               name=str(label)))
 
         for trace in data:
             if col is None or row is None:
@@ -176,8 +188,17 @@ def plot_embedding_interactive(
         title: The title on top of the embedding.
         figsize: Figure width and height in inches.
         dpi: Figure resolution.
-        kwargs: Optional arguments to customize the plots. See :py:class:`plotly.graph_objects.Scatter` documentation for more
-            details on which arguments to use.
+        kwargs: Optional arguments to customize the plots. This dictionary includes the following optional arguments:
+            -- showlegend: Whether to show the legend or not.
+            -- discrete: Whether the labels are discrete or not.
+            -- col: The column of the subplot to plot the embedding on.
+            -- row: The row of the subplot to plot the embedding on.
+            -- template: The template to use for the plot.
+
+            Note: showlegend can be True only if discrete is True.
+
+            See :py:class:`plotly.graph_objects.Scatter` documentation for more
+                details on which arguments to use.
 
     Returns:
         The plotly figure.

--- a/tests/test_plotly.py
+++ b/tests/test_plotly.py
@@ -84,3 +84,38 @@ def test_plot_embedding(output_dimension, idx_order):
 
     fig_subplots.data = []
     fig_subplots.layout = {}
+
+
+def test_discrete_with_legend():
+    embedding = np.random.uniform(0, 1, (1000, 3))
+    labels = np.random.randint(0, 10, (1000,))
+
+    fig = cebra_plotly.plot_embedding_interactive(embedding,
+                                                  labels,
+                                                  discrete=True,
+                                                  showlegend=True)
+
+    assert len(fig._data_objs) == np.unique(labels).shape[0]
+    assert isinstance(fig, go.Figure)
+
+
+def test_continuous_no_legend():
+    embedding = np.random.uniform(0, 1, (1000, 3))
+    labels = np.random.uniform(0, 1, (1000,))
+
+    fig = cebra_plotly.plot_embedding_interactive(embedding, labels)
+
+    assert len(fig._data_objs) == 1
+
+    assert isinstance(fig, go.Figure)
+
+
+def test_continuous_with_legend_raises_error():
+    embedding = np.random.uniform(0, 1, (1000, 3))
+    labels = np.random.uniform(0, 1, (1000,))
+
+    with pytest.raises(ValueError):
+        cebra_plotly.plot_embedding_interactive(embedding,
+                                                labels,
+                                                discrete=False,
+                                                showlegend=True)


### PR DESCRIPTION
Fixed `showlegend` `**kwargs` in plotly scatter 3D. 

```
from cebra.integrations.plotly import plot_embedding_interactive
import numpy as np

embedding = np.random.randn(100, 3)
labels = np.random.randint(0, 10, 100)

plot_embedding_interactive(embedding, labels, markersize=10, showlegend=True)
```
![Screenshot 2024-01-04 at 13 11 08](https://github.com/AdaptiveMotorControlLab/CEBRA/assets/41966024/cb08d7ce-c713-42f5-9209-5000310e5cc4)

```
plot_embedding_interactive(embedding, labels, markersize=10)
```
![Screenshot 2024-01-04 at 13 11 25](https://github.com/AdaptiveMotorControlLab/CEBRA/assets/41966024/ecf37a2c-7bff-4e2d-be5a-38db8e6aa580)