### PR TITLE
Fix pandas intersphinx mapping; fix test setup

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,7 @@ intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
     "scipy": ("http://docs.scipy.org/doc/scipy/reference/", None),
     "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
     "plotly": ("https://plotly.com/python-api-reference/", None)

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ docs =
     nbconvert
     ipykernel
     matplotlib<=3.5.2
-    pandas<2.2.0
+    pandas
     seaborn
     scikit-learn<1.3
 demos =

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,3 +105,4 @@ dev =
 
 [bdist_wheel]
 universal=1
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ dev =
     pytest-benchmark
     pytest-xdist
     pytest-timeout
-    pytest-sphinx
+    pytest-sphinx==0.5.0
     tables<=3.8
     licenseheaders
     # TODO(stes) Add back once upstream issue

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ docs =
     nbconvert
     ipykernel
     matplotlib<=3.5.2
-    pandas
+    pandas<2.2.0
     seaborn
     scikit-learn<1.3
 demos =

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ dev =
     isort
     toml
     coverage
-    pytest
+    pytest==7.4.4
     pytest-benchmark
     pytest-xdist
     pytest-timeout


### PR DESCRIPTION
In #135 , the tests show a few errors that are due to upstream changes in our dependencies. This PR fixes the build errors:

- Update the URL of the pandas intersphinx mapping to the current stable version (vs. the dev version, which we used previously). This fixes the issue during docs build due to a missing reference.
- Pin `pytest` and `pytest-sphinx` to a previous release --- we use `pytest-sphinx`, which is not yet compatible with the latest `pytest` version.