### PR TITLE
Extend type checking to all float datatypes

### DIFF
--- a/cebra/data/datasets.py
+++ b/cebra/data/datasets.py
@@ -107,7 +107,7 @@ class TensorDataset(cebra_data.SingleSessionDataset):
             if (check_dtype == "int" and not cebra.helper._is_integer(array)
                ) or (check_dtype == "float" and
                      not cebra.helper._is_floating(array)):
-                raise TypeError(f"{array.dtype} instead of {check_dtype}.")
+                raise TypeError(f"Array has type {array.dtype} instead of {check_dtype}.")
         return array
 
     @property

--- a/cebra/data/datasets.py
+++ b/cebra/data/datasets.py
@@ -24,7 +24,7 @@
 import abc
 import collections
 import types
-from typing import List, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 import literate_dataclasses as dataclasses
 import numpy as np
@@ -67,17 +67,16 @@ class TensorDataset(cebra_data.SingleSessionDataset):
 
     """
 
-    def __init__(
-        self,
-        neural: Union[torch.Tensor, npt.NDArray],
-        continuous: Union[torch.Tensor, npt.NDArray] = None,
-        discrete: Union[torch.Tensor, npt.NDArray] = None,
-        offset: int = 1,
-        device: str = "cpu"
-    ):
+    def __init__(self,
+                 neural: Union[torch.Tensor, npt.NDArray],
+                 continuous: Union[torch.Tensor, npt.NDArray] = None,
+                 discrete: Union[torch.Tensor, npt.NDArray] = None,
+                 offset: int = 1,
+                 device: str = "cpu"):
         super().__init__(device=device)
         self.neural = self._to_tensor(neural, check_dtype="float").float()
-        self.continuous = self._to_tensor(continuous, check_dtype="float").float()
+        self.continuous = self._to_tensor(continuous,
+                                          check_dtype="float").float()
         self.discrete = self._to_tensor(discrete, check_dtype="integer")
         if self.continuous is None and self.discrete is None:
             raise ValueError(
@@ -85,7 +84,11 @@ class TensorDataset(cebra_data.SingleSessionDataset):
             )
         self.offset = offset
 
-    def _to_tensor(self, array, check_dtype: str = None):
+    def _to_tensor(
+            self,
+            array: Union[torch.Tensor, npt.NDArray],
+            check_dtype: Optional[Literal["int",
+                                          "float"]] = None) -> torch.Tensor:
         """Convert :py:func:`numpy.array` to :py:class:`torch.Tensor` if necessary and check the dtype.
 
         Args:
@@ -101,9 +104,9 @@ class TensorDataset(cebra_data.SingleSessionDataset):
         if isinstance(array, np.ndarray):
             array = torch.from_numpy(array)
         if check_dtype is not None:
-            if (check_dtype == "integer" and not cebra.helper._is_integer(array)
-                ) or (check_dtype == "float" and not cebra.helper._is_floating(array)
-                ) or (check_dtype == "float_integer" and not cebra.helper._is_floating_or_integer(array)):
+            if (check_dtype == "int" and not cebra.helper._is_integer(array)
+               ) or (check_dtype == "float" and
+                     not cebra.helper._is_floating(array)):
                 raise TypeError(f"{array.dtype} instead of {check_dtype}.")
         return array
 

--- a/cebra/data/datasets.py
+++ b/cebra/data/datasets.py
@@ -76,7 +76,7 @@ class TensorDataset(cebra_data.SingleSessionDataset):
         super().__init__(device=device)
         self.neural = self._to_tensor(neural, check_dtype="float").float()
         self.continuous = self._to_tensor(continuous,
-                                          check_dtype="float").float()
+                                          check_dtype="float")
         self.discrete = self._to_tensor(discrete, check_dtype="integer")
         if self.continuous is None and self.discrete is None:
             raise ValueError(

--- a/cebra/helper.py
+++ b/cebra/helper.py
@@ -99,7 +99,7 @@ def _is_integer(y: Union[npt.NDArray, torch.Tensor]) -> bool:
 
 
 def _is_floating(y: Union[npt.NDArray, torch.Tensor]) -> bool:
-    """Check if the values in ``y`` are :py:class:`int`.
+    """Check if the values in ``y`` are :py:class:`float`.
 
     Note:
         There is no ``torch`` method to check that the ``dtype`` of a :py:class:`torch.Tensor`
@@ -116,6 +116,19 @@ def _is_floating(y: Union[npt.NDArray, torch.Tensor]) -> bool:
     return (isinstance(y, np.ndarray) and
             np.issubdtype(y.dtype, np.floating)) or (isinstance(
                 y, torch.Tensor) and torch.is_floating_point(y))
+
+
+def _is_floating_or_integer(y: Union[npt.NDArray, torch.Tensor]) -> bool:
+    """Check if the values in ``y`` are :py:class:`int` or :py:class:`float`.
+
+    Args:
+        y: An array, either as a :py:func:`numpy.array` or a :py:class:`torch.Tensor`.
+
+    Returns:
+        ``True`` if ``y`` contains :py:class:`float` or :py:class:`int`.
+    """
+
+    return _is_floating(y) or _is_integer(y)
 
 
 def get_loader_options(dataset: "cebra.data.Dataset") -> List[str]:


### PR DESCRIPTION
This allows for someone to use discrete labels in a continuous way; this might change the solver to behaviors you might not be expecting so please use with caution.

fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/791
fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/issues/790
