### PR TITLE
Add ruff for linting the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,7 @@ repos:
       - id: isort
         additional_dependencies:
           - pyproject.toml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.280
+    hooks:
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -579,4 +579,4 @@ max-complexity = 10
 
 [tool.ruff.per-file-ignores]
 # ignore import issues in __init__ files
-"__init__.py" = ["E402"]
+"__init__.py" = ["E402", "F403", "F405", "F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,3 +527,56 @@ overgeneral-exceptions=[
     'Exception',
     'BaseException',
 ]
+
+[tool.ruff]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Same as Black.
+line-length = 160
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.10.
+target-version = "py310"
+
+ignore-init-module-imports = true
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10
+
+[tool.ruff.per-file-ignores]
+# ignore import issues in __init__ files
+"__init__.py" = ["E402"]


### PR DESCRIPTION
Adds [`ruff`](https://docs.astral.sh/ruff/) for linting the whole codebase. Config is done in the `project.toml`, and added to the `pre-commit` hooks.

Fix https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/662

The actual fixes will be added to a dedicated PR to avoid clutter: https://github.com/AdaptiveMotorControlLab/CEBRA/pull/185