### PR TITLE
Fix tests for upgraded dependencies

### DIFF
--- a/cebra/datasets/monkey_reaching.py
+++ b/cebra/datasets/monkey_reaching.py
@@ -77,8 +77,12 @@ def _load_data(
             "Could not import the nlb_tools package required for data loading "
             "the raw reaching datasets in NWB format. "
             "If required, you can install the dataset by running "
-            "pip install nlb_tools or installing cebra with the [datasets] "
-            "dependencies: pip install 'cebra[datasets]'")
+            "pip install nlb_tools."
+            # NOTE(stes): Install nlb_tools manually for now, also see
+            # note in setup.cfg
+            # or installing cebra with the [datasets] "
+            #"dependencies: pip install 'cebra[datasets]'")
+        )
 
     def _get_info(trial_info, data):
         passive = []

--- a/cebra/integrations/plotly.py
+++ b/cebra/integrations/plotly.py
@@ -45,7 +45,7 @@ def _convert_cmap2colorscale(cmap: str, pl_entries: int = 11, rdigits: int = 2):
     """
     scale = np.linspace(0, 1, pl_entries)
     colors = (cmap(scale)[:, :3] * 255).astype(np.uint8)
-    pl_colorscale = [[round(s, rdigits), f"rgb{tuple(color)}"]
+    pl_colorscale = [[float(round(s, rdigits)), f"rgb{tuple(color.tolist())}"]
                      for s, color in zip(scale, colors)]
     return pl_colorscale
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ where =
 python_requires = >=3.9
 install_requires =
     joblib
+    numpy<2.0.0
     literate-dataclasses
     scikit-learn
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,13 @@ datasets =
     # cebra.datasets.allen
     h5py
     pandas
-    nlb_tools
+    # NOTE(stes): nlb_tools currently pins pandas to <1.3.4, see here:
+    # https://github.com/neurallatents/nlb_tools/blob/1ddc15f45b56388ff093d1396b7b87b36fa32a68/requirements.txt#L1
+    # Since this is a fairly old pandas version, it causes additional version
+    # conflicts with other packages. Removing nlb_tools as a required dependency for now.
+    # The only part this package is needed is in cebra/datasets/monkey_reaching.py, where
+    # we added a warning message to tell the user how to manually install it.
+    #nlb_tools
     # additional data loading dependencies
     hdf5storage # for creating .mat files in new format
     openpyxl # for excel file format loading


### PR DESCRIPTION
Update: The root issue was numpy 2. This is a recent upgrade (June 2024), and it seems like many of the packages required for cebra do not easily work with npy2 (yet). Errors included `pandas/pytables`, but also `torch`. It would be probably possible to work around these errors, but I think it is not worth yet --- in half a year or so, the situation is probably more stable, and we can remove the pinning.

This PR now does the following changes:

- Pin `numpy` below v2. 
- Remove `nlb_tools` to allow use of more recent pandas versions. This will only affect users who want to use the monkey dataset. We provide guidance on how to post-hoc install the package directly via a warning for these users.
- Fix a minor issue in the plotly code, which arises because we now use more recent versions of plotly.

I propose to merge as-is. From the user perspective, it is slightly annoying that CEBRA does not run with numpy 2 for now, but given the errors caused in other upstream packages, chances are that no one uses numpy 2 (yet) in the first place. We just still aim to remove the pinning again as soon as possible.


---

**Old description:**

This PR aims to solve some of the broken tests we saw in recent PRs (e.g. #166 #183 #175 #180 ). My hypothesis is that the `nlb_tools` package which we require for the test workflow right now is the root cause, which cases pandas to be downgraded to `1.3.4` (https://github.com/neurallatents/nlb_tools/blob/main/requirements.txt#L1), while the current pandas version is 2.2.3 (https://pypi.org/project/pandas/).

The build issue was a pandas <> numpy version mismatch (numpy was >2, pandas at 1.3.4 before), so hopefully this fixes the build.

I removed this depedency which causes more recent versions of all packages to be installed. This caused some plotly tests to break, which now do stricter checking on the colormaps. I also updated one of the helper functions there.

Let's see if this passes as-is on github, local tests look good.