### PR TITLE
Add improved goodness of fit implementation

### DIFF
--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -138,7 +138,7 @@ def goodness_of_fit_score(cebra_model: cebra_sklearn_cebra.CEBRA,
         >>> import cebra
         >>> import numpy as np
         >>> neural_data = np.random.uniform(0, 1, (1000, 20))
-        >>> cebra_model = cebra.CEBRA(max_iterations=10)
+        >>> cebra_model = cebra.CEBRA(max_iterations=10, batch_size = 512)
         >>> cebra_model.fit(neural_data)
         CEBRA(max_iterations=10)
         >>> gof = cebra.sklearn.metrics.goodness_of_fit_score(cebra_model, neural_data)
@@ -169,7 +169,7 @@ def goodness_of_fit_history(model):
         >>> import cebra
         >>> import numpy as np
         >>> neural_data = np.random.uniform(0, 1, (1000, 20))
-        >>> cebra_model = cebra.CEBRA(max_iterations=10)
+        >>> cebra_model = cebra.CEBRA(max_iterations=10, batch_size = 512)
         >>> cebra_model.fit(neural_data)
         CEBRA(max_iterations=10)
         >>> gof_history = cebra.sklearn.metrics.goodness_of_fit_history(cebra_model)
@@ -210,6 +210,11 @@ def infonce_to_goodness_of_fit(infonce: Union[float, Iterable[float]],
     """
     if not hasattr(model, "state_dict_"):
         raise RuntimeError("Fit the CEBRA model first.")
+    if model.batch_size is None:
+        raise ValueError(
+            "Computing the goodness of fit is not yet supported for "
+            "models trained on the full dataset (batchsize = None). " 
+        )
 
     nats_to_bits = np.log2(np.e)
     num_sessions = model.num_sessions_

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -208,7 +208,7 @@ def infonce_to_goodness_of_fit(infonce: Union[float, np.ndarray],
 
     Args:
         infonce: The InfoNCE loss, either a single value or an iterable of values.
-        model: The trained CEBRA model
+        model: The trained CEBRA model. 
         batch_size: The batch size used to train the model.
         num_sessions: The number of sessions used to train the model.
 

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -113,9 +113,11 @@ def goodness_of_fit_score(cebra_model: cebra_sklearn_cebra.CEBRA,
                           *y,
                           session_id: Optional[int] = None,
                           num_batches: int = 500) -> float:
-    """Compute the InfoNCE loss on a *single session* dataset on the model.
+    """Compute the goodness of fit score on a *single session* dataset on the model.
 
-    This function uses the :func:`infonce_loss` function to compute the InfoNCE loss.
+    This function uses the :func:`infonce_loss` function to compute the InfoNCE loss
+    for a given `cebra_model` and the :func:`infonce_to_goodness_of_fit` function 
+    to derive the goodness of fit from the InfoNCE loss.
 
     Args:
         cebra_model: The model to use to compute the InfoNCE loss on the samples.

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -154,7 +154,7 @@ def goodness_of_fit_score(cebra_model: cebra_sklearn_cebra.CEBRA,
     return infonce_to_goodness_of_fit(loss, cebra_model)
 
 
-def goodness_of_fit_history(model):
+def goodness_of_fit_history(model: cebra_sklearn_cebra.CEBRA) -> np.ndarray:
     """Return the history of the goodness of fit score.
 
     Args:

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -140,7 +140,7 @@ def goodness_of_fit_score(cebra_model: cebra_sklearn_cebra.CEBRA,
         >>> neural_data = np.random.uniform(0, 1, (1000, 20))
         >>> cebra_model = cebra.CEBRA(max_iterations=10, batch_size = 512)
         >>> cebra_model.fit(neural_data)
-        CEBRA(max_iterations=10)
+        CEBRA(batch_size=512, max_iterations=10)
         >>> gof = cebra.sklearn.metrics.goodness_of_fit_score(cebra_model, neural_data)
     """
     loss = infonce_loss(cebra_model,
@@ -171,7 +171,7 @@ def goodness_of_fit_history(model):
         >>> neural_data = np.random.uniform(0, 1, (1000, 20))
         >>> cebra_model = cebra.CEBRA(max_iterations=10, batch_size = 512)
         >>> cebra_model.fit(neural_data)
-        CEBRA(max_iterations=10)
+        CEBRA(batch_size=512, max_iterations=10)
         >>> gof_history = cebra.sklearn.metrics.goodness_of_fit_history(cebra_model)
     """
     infonce = np.array(model.state_dict_["log"]["total"])

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -141,7 +141,7 @@ def goodness_of_fit_score(cebra_model: cebra_sklearn_cebra.CEBRA,
         >>> cebra_model = cebra.CEBRA(max_iterations=10)
         >>> cebra_model.fit(neural_data)
         CEBRA(max_iterations=10)
-        >>> gof = cebra.goodness_of_fit_score(cebra_model, neural_data)
+        >>> gof = cebra.sklearn.metrics.goodness_of_fit_score(cebra_model, neural_data)
     """
     loss = infonce_loss(cebra_model,
                         X,
@@ -172,7 +172,7 @@ def goodness_of_fit_history(model):
         >>> cebra_model = cebra.CEBRA(max_iterations=10)
         >>> cebra_model.fit(neural_data)
         CEBRA(max_iterations=10)
-        >>> gof_history = cebra.goodness_of_fit_history(cebra_model)
+        >>> gof_history = cebra.sklearn.metrics.goodness_of_fit_history(cebra_model)
     """
     infonce = np.array(model.state_dict_["log"]["total"])
     return infonce_to_goodness_of_fit(infonce, model)
@@ -215,7 +215,7 @@ def infonce_to_goodness_of_fit(infonce: Union[float, Iterable[float]],
     num_sessions = model.num_sessions_
     if num_sessions is None:
         num_sessions = 1
-    chance_level = np.log(model.batch_size * (model.num_sessions_ or 1))
+    chance_level = np.log(model.batch_size * num_sessions)
     return (chance_level - infonce) * nats_to_bits
 
 

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -116,7 +116,7 @@ def goodness_of_fit_score(cebra_model: cebra_sklearn_cebra.CEBRA,
     """Compute the goodness of fit score on a *single session* dataset on the model.
 
     This function uses the :func:`infonce_loss` function to compute the InfoNCE loss
-    for a given `cebra_model` and the :func:`infonce_to_goodness_of_fit` function 
+    for a given `cebra_model` and the :func:`infonce_to_goodness_of_fit` function
     to derive the goodness of fit from the InfoNCE loss.
 
     Args:
@@ -180,10 +180,11 @@ def goodness_of_fit_history(model: cebra_sklearn_cebra.CEBRA) -> np.ndarray:
     return infonce_to_goodness_of_fit(infonce, model)
 
 
-def infonce_to_goodness_of_fit(infonce: Union[float, np.ndarray],
-                               model: Optional[cebra_sklearn_cebra.CEBRA] = None,
-                               batch_size: Optional[int] = None,
-                               num_sessions: Optional[int] = None) -> Union[float, np.ndarray]:
+def infonce_to_goodness_of_fit(
+        infonce: Union[float, np.ndarray],
+        model: Optional[cebra_sklearn_cebra.CEBRA] = None,
+        batch_size: Optional[int] = None,
+        num_sessions: Optional[int] = None) -> Union[float, np.ndarray]:
     """Given a trained CEBRA model, return goodness of fit metric.
 
     The goodness of fit ranges from 0 (lowest meaningful value)
@@ -208,7 +209,7 @@ def infonce_to_goodness_of_fit(infonce: Union[float, np.ndarray],
 
     Args:
         infonce: The InfoNCE loss, either a single value or an iterable of values.
-        model: The trained CEBRA model. 
+        model: The trained CEBRA model.
         batch_size: The batch size used to train the model.
         num_sessions: The number of sessions used to train the model.
 
@@ -221,27 +222,32 @@ def infonce_to_goodness_of_fit(infonce: Union[float, np.ndarray],
     """
     if model is not None:
         if batch_size is not None or num_sessions is not None:
-            raise ValueError("batch_size and num_sessions should not be provided if model is provided.")
+            raise ValueError(
+                "batch_size and num_sessions should not be provided if model is provided."
+            )
         if not hasattr(model, "state_dict_"):
             raise RuntimeError("Fit the CEBRA model first.")
         if model.batch_size is None:
             raise ValueError(
                 "Computing the goodness of fit is not yet supported for "
-                "models trained on the full dataset (batchsize = None). " 
-            )
+                "models trained on the full dataset (batchsize = None). ")
         batch_size = model.batch_size
         num_sessions = model.num_sessions_
         if num_sessions is None:
             num_sessions = 1
+
+        if model.batch_size is None:
+            raise ValueError(
+                "Computing the goodness of fit is not yet supported for "
+                "models trained on the full dataset (batchsize = None). ")
     else:
         if batch_size is None or num_sessions is None:
             raise ValueError(
-                  f"batch_size ({batch_size}) and num_sessions ({num_sessions})"
-                  f"should be provided if model is not provided."
-            )
+                f"batch_size ({batch_size}) and num_sessions ({num_sessions})"
+                f"should be provided if model is not provided.")
 
     nats_to_bits = np.log2(np.e)
-    chance_level = np.log(model.batch_size * num_sessions)
+    chance_level = np.log(batch_size * num_sessions)
     return (chance_level - infonce) * nats_to_bits
 
 

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -206,7 +206,7 @@ def infonce_to_goodness_of_fit(infonce: Union[float, Iterable[float]],
         Numpy array containing the goodness of fit values, measured in bits
 
     Raises:
-        ``RuntimeError``, if provided model is not fit to data.
+        RuntimeError: If the provided model is not fit to data.
     """
     if not hasattr(model, "state_dict_"):
         raise RuntimeError("Fit the CEBRA model first.")

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -235,7 +235,10 @@ def infonce_to_goodness_of_fit(infonce: Union[float, np.ndarray],
             num_sessions = 1
     else:
         if batch_size is None or num_sessions is None:
-            raise ValueError("batch_size should be provided if model is not provided.")
+            raise ValueError(
+                  f"batch_size ({batch_size}) and num_sessions ({num_sessions})"
+                  f"should be provided if model is not provided."
+            )
 
     nats_to_bits = np.log2(np.e)
     chance_level = np.log(model.batch_size * num_sessions)

--- a/tests/test_sklearn_metrics.py
+++ b/tests/test_sklearn_metrics.py
@@ -395,8 +395,9 @@ def test_goodness_of_fit_score(seed):
         max_iterations=5,
         batch_size=512,
     )
-    X = torch.tensor(np.random.uniform(0, 1, (5000, 50)))
-    y = torch.tensor(np.random.uniform(0, 1, (5000, 5)))
+    generator = torch.Generator().manual_seed(seed)
+    X = torch.rand(5000, 50, dtype=torch.float32, generator=generator)
+    y = torch.rand(5000, 5, dtype=torch.float32, generator=generator)
     cebra_model.fit(X, y)
     score = cebra_sklearn_metrics.goodness_of_fit_score(cebra_model,
                                                         X,
@@ -447,3 +448,66 @@ def test_goodness_of_fit_history(seed):
     assert history_linear.shape[0] > 0
 
     assert np.all(history_linear[-20:] > history_random[-20:])
+
+
+@pytest.mark.parametrize("seed", [42, 24, 10])
+def test_infonce_to_goodness_of_fit(seed):
+    """Test the conversion from InfoNCE loss to goodness of fit metric."""
+    # Test with model
+    cebra_model = cebra_sklearn_cebra.CEBRA(
+        model_architecture="offset10-model",
+        max_iterations=5,
+        batch_size=128,
+    )
+    generator = torch.Generator().manual_seed(seed)
+    X = torch.rand(1000, 50, dtype=torch.float32, generator=generator)
+    cebra_model.fit(X)
+
+    # Test single value
+    gof = cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
+                                                           model=cebra_model)
+    assert isinstance(gof, float)
+
+    # Test array of values
+    infonce_values = np.array([1.0, 2.0, 3.0])
+    gof_array = cebra_sklearn_metrics.infonce_to_goodness_of_fit(
+        infonce_values, model=cebra_model)
+    assert isinstance(gof_array, np.ndarray)
+    assert gof_array.shape == infonce_values.shape
+
+    # Test with explicit batch_size and num_sessions
+    gof = cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
+                                                           batch_size=128,
+                                                           num_sessions=1)
+    assert isinstance(gof, float)
+
+    # Test error cases
+    with pytest.raises(ValueError, match="batch_size.*should not be provided"):
+        cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
+                                                         model=cebra_model,
+                                                         batch_size=128)
+
+    with pytest.raises(ValueError, match="batch_size.*should not be provided"):
+        cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
+                                                         model=cebra_model,
+                                                         num_sessions=1)
+
+    # Test with unfitted model
+    unfitted_model = cebra_sklearn_cebra.CEBRA()
+    with pytest.raises(RuntimeError, match="Fit the CEBRA model first"):
+        cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
+                                                         model=unfitted_model)
+
+    # Test with model having batch_size=None
+    none_batch_model = cebra_sklearn_cebra.CEBRA(batch_size=None)
+    none_batch_model.fit(X)
+    with pytest.raises(ValueError, match="Computing the goodness of fit"):
+        cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
+                                                         model=none_batch_model)
+
+    # Test missing batch_size or num_sessions when model is None
+    with pytest.raises(ValueError, match="batch_size.*and num_sessions"):
+        cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0, batch_size=128)
+
+    with pytest.raises(ValueError, match="batch_size.*and num_sessions"):
+        cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0, num_sessions=1)

--- a/tests/test_sklearn_metrics.py
+++ b/tests/test_sklearn_metrics.py
@@ -493,13 +493,14 @@ def test_infonce_to_goodness_of_fit(seed):
                                                          num_sessions=1)
 
     # Test with unfitted model
-    unfitted_model = cebra_sklearn_cebra.CEBRA()
+    unfitted_model = cebra_sklearn_cebra.CEBRA(max_iterations=5)
     with pytest.raises(RuntimeError, match="Fit the CEBRA model first"):
         cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,
                                                          model=unfitted_model)
 
     # Test with model having batch_size=None
-    none_batch_model = cebra_sklearn_cebra.CEBRA(batch_size=None)
+    none_batch_model = cebra_sklearn_cebra.CEBRA(batch_size=None,
+                                                 max_iterations=5)
     none_batch_model.fit(X)
     with pytest.raises(ValueError, match="Computing the goodness of fit"):
         cebra_sklearn_metrics.infonce_to_goodness_of_fit(1.0,

--- a/tests/test_sklearn_metrics.py
+++ b/tests/test_sklearn_metrics.py
@@ -441,7 +441,7 @@ def test_goodness_of_fit_history(seed):
     # NOTE(stes): Ignore the first 5 iterations, they can have nonsensical values
     # due to numerical issues.
     history_random_non_negative = history_random[history_random >= 0]
-    np.testing.assert_allclose(history_random_non_negative, 0, atol=0.05)
+    np.testing.assert_allclose(history_random_non_negative, 0, atol=0.075)
 
     assert isinstance(history_linear, np.ndarray)
     assert history_linear.shape[0] > 0


### PR DESCRIPTION
This adds a better goodness of fit measure. Instead of the old variant which simply matched the InfoNCE and depends on the batch size, the proposed measure

- is at 0 for "chance level" (vs. log batch size)
- does not need an adjustment for single session vs. multi-session solvers
- increases as the model gets better, which might be more intuitive

The conversion is quite simply done via

```
GoF(model) = log (batch_size_per_session * num_sessions) - InfoNCE(model)
```

This measure is also used in [DeWolf et al., 2024, Eq. (43)](https://www.biorxiv.org/content/10.1101/2024.09.11.612513v1)

![image](https://github.com/user-attachments/assets/93ba9e35-34d3-4df4-b90e-1d3ccb96326e)

Application example (GoF improves from 0 to a larger value during training):

<img width="879" alt="image" src="https://github.com/user-attachments/assets/21be303a-0e1d-42f5-8307-c209e475440f" />



---

OLD example, for comparison

![image](https://github.com/user-attachments/assets/b0572c85-792f-4e9d-9d23-bd62518fc206)


---

Close https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/669