### PR TITLE
Fix `scikit-learn` reference in conda environment files

### DIFF
--- a/conda/cebra_paper.yml
+++ b/conda/cebra_paper.yml
@@ -39,7 +39,7 @@ dependencies:
         - "cebra[dev,integrations,datasets,demos]"
         - joblib
         - literate-dataclasses
-        - sklearn
+        - scikit-learn
         - scipy
         - torch
         - keras==2.3.1

--- a/conda/cebra_paper_m1.yml
+++ b/conda/cebra_paper_m1.yml
@@ -48,7 +48,7 @@ dependencies:
         - tensorflow-metal
         - joblib
         - literate-dataclasses
-        - sklearn
+        - scikit-learn
         - scipy
         - torch
         - umap-learn


### PR DESCRIPTION
Update the `sklearn` ref in the conda files to `scikit-learn` as discussed [here](https://github.com/scikit-learn/sklearn-pypi-package).

Fix #194 