### PR TITLE
Add goodness of fit metric

### DIFF
--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -117,9 +117,7 @@ def goodness_of_fit(model: cebra_sklearn_cebra.CEBRA) -> List[float]:
     different batch sizes or different implementations.
 
     Args: 
-        model: The model to evaluate. This can be an instance of either 
-            `cebra_sklearn_cebra.CEBRA` or `cebra_solver.Solver`.
-        batch_size: Batch size used to train the model.
+        model: The model to evaluate. This is an instance of `cebra_sklearn_cebra.CEBRA`.
 
     Returns: 
         A list of float values representing the goodness of fit for the model.


### PR DESCRIPTION
- Add the goodness of fit computation function and wrapper function to be used directly on a `cebra.CEBRA` model (sklearn implementation only). The goodness of fit computation function can be applied on `solver.history` (loss) for the pytorch implementation, and in that case the batch size needs to be provided.
- Add corresponding tests.

Note that it is not implemented for batch size set to `None`.