### PR TITLE
Add support for new __sklearn_tags__

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,17 @@ jobs:
         # as well as selected previous versions on
         # https://pytorch.org/get-started/previous-versions/
         torch-version: ["2.2.2", "2.4.0"]
+        sklearn-version: ["latest"]
         include:
           - os: windows-latest
             torch-version: 2.4.0
             python-version: "3.10"
+            sklearn-version: "latest"
+        include:
+          - os: ubuntu-latest 
+            torch-version: 2.4.0
+            python-version: "3.10"
+            sklearn-version: "legacy"
 
     runs-on: ${{ matrix.os }}
 
@@ -32,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: pip-os_${{ runner.os }}-python_${{ matrix.python-version }}-torch_${{ matrix.torch-version }}
+          key: pip-os_${{ runner.os }}-python_${{ matrix.python-version }}-torch_${{ matrix.torch-version }}-sklearn_${{ matrix.sklearn-version }}
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -47,6 +54,11 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install torch==${{ matrix.torch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
           pip install '.[dev,datasets,integrations]'
+
+      - name: Check sklearn legacy version 
+        if: matrix.sklearn-version == 'legacy'
+        run: |
+          pip install scikit-learn==1.4.2 '.[dev,datasets,integrations]'
 
       - name: Run the formatter
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
             torch-version: 2.4.0
             python-version: "3.10"
             sklearn-version: "latest"
-        include:
           - os: ubuntu-latest 
             torch-version: 2.4.0
             python-version: "3.10"

--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -371,7 +371,7 @@ def _load_cebra_with_sklearn_backend(cebra_info: Dict) -> "CEBRA":
     return cebra_
 
 
-class CEBRA(BaseEstimator, TransformerMixin):
+class CEBRA(TransformerMixin, BaseEstimator):
     """CEBRA model defined as part of a ``scikit-learn``-like API.
 
     Attributes:


### PR DESCRIPTION
Fix #204 

sklearn 1.6.0 was released on Dec 9, 24 and introduced a new mechanism for specifying estimator tags (https://scikit-learn.org/dev/developers/develop.html). This PR adopts CEBRA to comply with this new notation. Older sklearn variants will fall back to the `more_tags()` functions as recommended [in this comment](https://github.com/scikit-learn/scikit-learn/pull/29677#issuecomment-2334229165).

Indepedently, I spotted a bug in the inheritance order in the CEBRA class, which was fixed now, as described [here](https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator).

Finally, since the code is now version dependent and there might be users rolling older sklearn version, I extended the test suite by one case checking with a legacy sklearn version (version 1.4.2 which is roughly one year old) -- this will hopefully cover the most important cases. The majority of tests are with sklearn latest (1.6.0 as of Dec 16, 24).