### PR TITLE
Update workflows to actions/setup-python@v5, actions/cache@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             torch-version: 2.4.0
             python-version: "3.10"
             sklearn-version: "latest"
-          - os: ubuntu-latest 
+          - os: ubuntu-latest
             torch-version: 2.4.0
             python-version: "3.10"
             sklearn-version: "legacy"
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -54,7 +54,7 @@ jobs:
           python -m pip install torch==${{ matrix.torch-version }} --extra-index-url https://download.pytorch.org/whl/cpu
           pip install '.[dev,datasets,integrations]'
 
-      - name: Check sklearn legacy version 
+      - name: Check sklearn legacy version
         if: matrix.sklearn-version == 'legacy'
         run: |
           pip install scikit-learn==1.4.2 '.[dev,datasets,integrations]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Cache dependencies
         id: pip-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-os_${{ runner.os }}-python_${{ matrix.python-version }}-torch_${{ matrix.torch-version }}-sklearn_${{ matrix.sklearn-version }}

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -38,7 +38,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -31,7 +31,7 @@ jobs:
     #  with:
     #    ref: main
     - uses: actions/checkout@v3
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
 
     steps:
     # NOTE(stes) currently not used, we check
@@ -38,7 +38,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           ref: main
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -60,12 +60,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           # NOTE(stes) Pandoc version must be at least (2.14.2) but less than (4.0.0).
-          # as of 29/10/23. Ubuntu 22.04 which is used for ubuntu-latest only has an 
+          # as of 29/10/23. Ubuntu 22.04 which is used for ubuntu-latest only has an
           # old pandoc version (2.9.). We will hence install the latest version manually.
           # previou: sudo apt-get install -y pandoc
-          wget https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-1-amd64.deb 
-          sudo dpkg -i pandoc-3.1.9-1-amd64.deb 
-          rm pandoc-3.1.9-1-amd64.deb 
+          wget https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-1-amd64.deb
+          sudo dpkg -i pandoc-3.1.9-1-amd64.deb
+          rm pandoc-3.1.9-1-amd64.deb
           pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
           pip install '.[docs]'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Cache dependencies
         id: pip-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           ref: main
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Cache dependencies
         id: pip-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip


### PR DESCRIPTION
Several current PRs, eg #206 #189  fail due to an outdated python action.

![image](https://github.com/user-attachments/assets/ab6c8150-61c2-4770-bb2c-fba3deaf1ae3)

This PR upgrades all actions to v5, the latest version (https://github.com/actions/setup-python/blob/1928ae624dc06094d8c65f021a4700ea8fa56b9d/README.md).

In the same spirit we update actions/cache from outdated version to v4 to avoid the deprecation scheduled to happen soon.