### PR TITLE
[WIP] Add RegCL training (AISTATS 2025)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN make dist
 FROM cebra-base
 
 # install the cebra wheel
-ENV WHEEL=cebra-0.4.0-py2.py3-none-any.whl
+ENV WHEEL=cebra-0.4.0+regcl-py2.py3-none-any.whl
 WORKDIR /build
 COPY --from=wheel /build/dist/${WHEEL} .
 RUN pip install --no-cache-dir ${WHEEL}'[dev,integrations,datasets]'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CEBRA_VERSION := 0.4.0
+CEBRA_VERSION := 0.4.0+regcl
 
 dist:
 	python3 -m pip install virtualenv

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Steffen Schneider <stes@hey.com>
 pkgname=python-cebra
 _pkgname=cebra
-pkgver=0.4.0
+pkgver=0.4.0+regcl
 pkgrel=1
 pkgdesc="Consistent Embeddings of high-dimensional Recordings using Auxiliary variables"
 url="https://cebra.ai"

--- a/cebra/__init__.py
+++ b/cebra/__init__.py
@@ -66,7 +66,7 @@ except (ImportError, NameError):
 
 import cebra.integrations.sklearn as sklearn
 
-__version__ = "0.4.0"
+__version__ = "0.4.0+regcl"
 __all__ = ["CEBRA"]
 __allow_lazy_imports = False
 __lazy_imports = {}

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -15,7 +15,7 @@ pip uninstall -y cebra
 # Get version info after uninstalling --- this will automatically get the
 # most recent version based on the source code in the current directory.
 # $(tools/get_cebra_version.sh)
-VERSION=0.4.0
+VERSION=0.4.0+regcl
 echo "Upgrading to CEBRA v${VERSION}"
 
 # Upgrade the build system (PEP517/518 compatible)


### PR DESCRIPTION
This PR will add the code for the paper "Identifiable attribution maps using regularized contrastive learning" (AISTATS 2025). Code release is work in progress.

The PR will add:
- A new API for training models with multiple objectives.
- The option to regularize model training with a Jacobian regularizer ("RegCL").
- Functionality for computing attribution map of latents with respect to the model input. For identifiable attribution maps, use RegCL training plus the new Inverse Neuron Gradient method. Further methods from the captum library are added for reference.

---

Original PR: https://github.com/AdaptiveMotorControlLab/CEBRA-dev/pull/783