### PR TITLE
Refactoring setup.cfg

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,28 @@
+<img src="https://github.com/user-attachments/assets/1f327e57-8ee1-4a2f-afd3-2bbce885c2f8" width="200"/>
+
+
+
+CEBRA was initially developed by **Mackenzie Mathis** and **Steffen Schneider** (2021+), who are co-inventors on the patent application [WO2023143843](https://infoscience.epfl.ch/entities/patent/0d9debed-4d22-47b7-bad1-f211e7010323). 
+**Jin Hwa Lee** contributed significantly to our first paper:  
+
+> **Schneider, S., Lee, J.H., & Mathis, M.W.**  
+> [*Learnable latent embeddings for joint behavioural and neural analysis.*](https://doi.org/10.1038/s41586-023-06031-6) 
+> Nature 617, 360–368 (2023)
+
+CEBRA is actively developed by [**Mackenzie Mathis**](https://www.mackenziemathislab.org/) and [**Steffen Schneider**](https://dynamical-inference.ai/) and their labs.  
+
+It is a publicly available tool that has benefited from contributions and suggestions from many individuals: [CEBRA/graphs/contributors](https://github.com/AdaptiveMotorControlLab/CEBRA/graphs/contributors).  
+
+## CEBRA Extensions 
+
+### 2023  
+- **Steffen Schneider, Rodrigo González Laiz, Markus Frey, Mackenzie W. Mathis**  
+  [*Identifiable attribution maps using regularized contrastive learning.*](https://sslneurips23.github.io/paper_pdfs/paper_80.pdf) 
+  NeurIPS 4th Workshop on Self-Supervised Learning: Theory and Practice (2023)
+
+### 2025  
+- **Steffen Schneider, Rodrigo González Laiz, Anastasiia Filippova, Markus Frey, Mackenzie W. Mathis**  
+  [*Time-series attribution maps with regularized contrastive learning.*](https://openreview.net/forum?id=aGrCXoTB4P)  
+  AISTATS (2025)
+
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,6 @@ docs =
     seaborn
     scikit-learn
     numpy<2.0.0
-    plotly
 demos =
     ipykernel
     jupyter

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/AdaptiveMotorControlLab/CEBRA
 project_urls =
     Bug Tracker = https://github.com/AdaptiveMotorControlLab/CEBRA/issues
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 4 - Beta
     Environment :: GPU :: NVIDIA CUDA
     Intended Audience :: Science/Research
     Operating System :: OS Independent

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,11 +79,11 @@ docs =
     seaborn
     scikit-learn
     numpy<2.0.0
+    plotly
 demos =
     ipykernel
-    nbconvert
-    seaborn
     jupyter
+    nbconvert
     # TODO(stes): Additional dependency for running
     # co-homology analysis
     # is ripser, which can be tricky to

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
 name = cebra
 version = attr: cebra.__version__
-author = Steffen Schneider, Jin H Lee, Mackenzie W Mathis
-author_email = stes@hey.com
+author = file: AUTHORS.md
+author_email = stes@hey.com, mackenzie@post.harvard.edu
 description = Consistent Embeddings of high-dimensional Recordings using Auxiliary variables
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -12,7 +12,7 @@ url = https://github.com/AdaptiveMotorControlLab/CEBRA
 project_urls =
     Bug Tracker = https://github.com/AdaptiveMotorControlLab/CEBRA/issues
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Environment :: GPU :: NVIDIA CUDA
     Intended Audience :: Science/Research
     Operating System :: OS Independent

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,9 +58,9 @@ datasets =
     hdf5storage # for creating .mat files in new format
     openpyxl # for excel file format loading
 integrations =
-    jupyter
     pandas
     plotly
+    seaborn
 docs =
     sphinx==5.3
     sphinx-gallery==0.10.1
@@ -81,9 +81,9 @@ docs =
     numpy<2.0.0
 demos =
     ipykernel
-    jupyter
     nbconvert
     seaborn
+    jupyter
     # TODO(stes): Additional dependency for running
     # co-homology analysis
     # is ripser, which can be tricky to


### PR DESCRIPTION
The goal is to consolidate the setup options. Note, this may cause backwards changes in people's installation setup, but is a minor change.

added an authors page with new links to CEBRA extensions