### PR TITLE
Update assets.py --> force check for parent dir

### DIFF
--- a/cebra/data/assets.py
+++ b/cebra/data/assets.py
@@ -93,7 +93,7 @@ def download_file_with_progress_bar(url: str,
         )
 
     # Create the directory and any necessary parent directories
-    location_path.mkdir(exist_ok=True)
+    location_path.mkdir(parents=True, exist_ok=True)
 
     filename = filename_match.group(1)
     file_path = location_path / filename


### PR DESCRIPTION
- mkdir was failing in data download in 0.5.0rc1; attempt to fix; I think this is effectively a small revert of a change introduced in #169 

locally works: 

```
In [1]: import cebra

In [2]: import cebra.datasets
   ...: from cebra import CEBRA

In [3]: hippocampus_pos = cebra.datasets.init('rat-hippocampus-single-achilles')
100%|████████████████████████████████████████████████████████████████| 10.0M/10.0M [00:00<00:00, 31.3MB/s]
Download complete. Dataset saved in 'data/rat_hippocampus/achilles.jl'
```