### PR TITLE
render plotly in our docs, show code/doc version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,12 @@ on:
       - main
       - public
       - dev
+    paths:
+      - '**.py'
+      - '**.ipynb'
+      - '**.js'
+      - '**.rst'
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,7 @@ jobs:
           rm pandoc-3.1.9-1-amd64.deb
           pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
           pip install '.[docs]'
+          pip install plotly
 
       - name: Build docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,6 +69,8 @@ jobs:
           pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
           pip install '.[docs]'
           pip install plotly
+          pip install nbsphinx
+
 
       - name: Build docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,8 +68,6 @@ jobs:
           rm pandoc-3.1.9-1-amd64.deb
           pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
           pip install '.[docs]'
-          pip install plotly
-          pip install nbsphinx
 
 
       - name: Build docs

--- a/cebra/integrations/plotly.py
+++ b/cebra/integrations/plotly.py
@@ -28,6 +28,7 @@ import numpy as np
 import numpy.typing as npt
 import plotly.graph_objects
 import torch
+import plotly.graph_objects as go
 
 from cebra.integrations.matplotlib import _EmbeddingPlot
 
@@ -154,7 +155,7 @@ class _EmbeddingInteractivePlot(_EmbeddingPlot):
 def plot_embedding_interactive(
     embedding: Union[npt.NDArray, torch.Tensor],
     embedding_labels: Optional[Union[npt.NDArray, torch.Tensor, str]] = "grey",
-    axis: Optional[plotly.graph_objects.Figure] = None,
+    axis: Optional["go.Figure"] = None,
     markersize: float = 1,
     idx_order: Optional[Tuple[int]] = None,
     alpha: float = 0.4,
@@ -163,7 +164,7 @@ def plot_embedding_interactive(
     figsize: Tuple[int] = (5, 5),
     dpi: int = 100,
     **kwargs,
-) -> plotly.graph_objects.Figure:
+) -> "go.Figure":
     """Plot embedding in a 3D dimensional space.
 
     This is supposing that the dimensions provided to ``idx_order`` are in the range of the number of

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,6 +18,11 @@ help:
 html:
 	PYTHONPATH=.. $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+# Build multiple versions
+html_versions:
+	for v in latest v0.2.0 v0.3.0 v0.4.0; do \
+		PYTHONPATH=.. $(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/$$v"; \
+	done
 # Remove the current temp folder and page build
 clean:
 	rm -rf build

--- a/docs/source/_static/css/custom.js
+++ b/docs/source/_static/css/custom.js
@@ -1,0 +1,6 @@
+requirejs.config({
+    paths: {
+        base: '/static/base',
+        plotly: 'https://cdn.plot.ly/plotly-2.12.1.min.js?noext',
+    },
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -163,11 +163,6 @@ html_context = {
 html_theme_options = {
     "icon_links": [
         {
-            "name": "Home",
-            "url": "https://cebra.ai/",
-            "icon": "fa-solid fa-house",
-        },
-        {
             "name": "Github",
             "url": "https://github.com/AdaptiveMotorControlLab/CEBRA",
             "icon": "fab fa-github",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,9 +64,6 @@ html_js_files = [
     "custom.js",
 ]
 
-def setup(app):
-    app.add_javascript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js')
-
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ def get_years(start_year=2021):
 # -- Project information -----------------------------------------------------
 project = "cebra"
 copyright = f"""{get_years(2021)}"""
-author = "See CEBRA.ai"
+author = "See AUTHORS.md"
 # The full version, including alpha/beta/rc tags
 release = cebra.__version__
 
@@ -162,6 +162,11 @@ html_context = {
 # https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html
 html_theme_options = {
     "icon_links": [
+        {
+            "name": "Home",
+            "url": "https://cebra.ai/",
+            "icon": "fa-solid fa-house",
+        },
         {
             "name": "Github",
             "url": "https://github.com/AdaptiveMotorControlLab/CEBRA",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,9 @@ release = cebra.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+import plotly.io as pio
+pio.renderers.default = "sphinx_gallery"
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
@@ -68,12 +71,13 @@ extensions = [
     "sphinx_tabs.tabs",
     "sphinx.ext.mathjax",
     "IPython.sphinxext.ipython_console_highlighting",
-    # "sphinx_panels", # Note: package to avoid: no longer maintained.
     "sphinx_design",
     "sphinx_togglebutton",
     "sphinx.ext.doctest",
     "sphinx_gallery.load_style",
+    "sphinx.ext.plotly_directive",  # Added Plotly extension
 ]
+
 
 coverage_show_missing_items = True
 panels_add_bootstrap_css = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,6 @@ extensions = [
     "sphinx_togglebutton",
     "sphinx.ext.doctest",
     "sphinx_gallery.load_style",
-    "sphinx.ext.plotly_directive",  # Added Plotly extension
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,8 +57,12 @@ release = cebra.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-import plotly.io as pio
-pio.renderers.default = "sphinx_gallery"
+
+#https://github.com/spatialaudio/nbsphinx/issues/128#issuecomment-1158712159
+html_js_files = [
+    "require.min.js",  # Add to your _static
+    "custom.js",
+]
 
 def setup(app):
     app.add_javascript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,6 +144,20 @@ exclude_patterns = [
 # a list of builtin themes.
 html_theme = "pydata_sphinx_theme"
 
+html_context = {
+    "default_mode": "light",
+    "switcher": {
+        "version_match": "latest",  # Adjust this dynamically per version
+        "versions": [
+            ("latest", "/latest/"),
+            ("v0.2.0", "/v0.2.0/"),
+            ("v0.3.0", "/v0.3.0/"),
+            ("v0.4.0", "/v0.4.0/"),
+            ("v0.5.0rc1", "/v0.5.0rc1/"),
+        ],
+    },
+}
+
 # More info on theme options:
 # https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html
 html_theme_options = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,6 +156,7 @@ html_context = {
             ("v0.5.0rc1", "/v0.5.0rc1/"),
         ],
     },
+    "navbar_start": ["version-switcher", "navbar-logo"],  # Place the dropdown above the logo
 }
 
 # More info on theme options:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,8 +47,8 @@ def get_years(start_year=2021):
 
 # -- Project information -----------------------------------------------------
 project = "cebra"
-copyright = f"""{get_years(2021)}, Steffen Schneider, Jin H Lee, Mackenzie Mathis"""
-author = "Steffen Schneider, Jin H Lee, Mackenzie Mathis"
+copyright = f"""{get_years(2021)}"""
+author = "See CEBRA.ai"
 # The full version, including alpha/beta/rc tags
 release = cebra.__version__
 
@@ -59,6 +59,9 @@ release = cebra.__version__
 # ones.
 import plotly.io as pio
 pio.renderers.default = "sphinx_gallery"
+
+def setup(app):
+    app.add_javascript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js')
 
 extensions = [
     "sphinx.ext.autodoc",


### PR DESCRIPTION
The issue was that plotly was not rendering in our sphinx docs

Solution is from: https://github.com/spatialaudio/nbsphinx/issues/128#issuecomment-1158712159

Also took inspiration from https://github.com/VectorInstitute/cyclops/pull/591 

Added version builds