### PR TITLE
Allow indexing of the cebra docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,14 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - public
-      - dev
-    paths:
-      - '**.py'
-      - '**.ipynb'
-      - '**.js'
-      - '**.rst'
-      - '**.md'
 
 jobs:
   build:

--- a/docs/root/robots.txt
+++ b/docs/root/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
 Disallow: /staging/
-Disallow: /docs/


### PR DESCRIPTION
This is an oversight from an early release; now that docs are stable, we should let search engines index the docs.