### PR TITLE
Decouple batch size and number of negatives

### DIFF
--- a/cebra/data/base.py
+++ b/cebra/data/base.py
@@ -288,7 +288,8 @@ class Loader(abc.ABC, cebra.io.HasDevice):
 
 
         Note:
-            From version 0.7.0 onwards, `num_negatives` parameter was added to allow
-            specifying a different number of negative samples compared to the batch size.
+            From version 0.7.0 onwards, specifying the ``num_samples`` and
+            ``num_negatives`` directly was deprecated. Please set these
+            variables via the attributes ``batch_size`` and ``num_negatives``.
         """
         raise NotImplementedError()

--- a/cebra/data/base.py
+++ b/cebra/data/base.py
@@ -273,7 +273,7 @@ class Loader(abc.ABC, cebra.io.HasDevice):
             yield self.dataset.load_batch(index)
 
     @abc.abstractmethod
-    def get_indices(self, num_samples: int = None):
+    def get_indices(self, *, num_samples: int = None):
         """Sample and return the specified number of indices.
 
         The elements of the returned `BatchIndex` will be used to index the

--- a/cebra/data/base.py
+++ b/cebra/data/base.py
@@ -22,6 +22,7 @@
 """Base classes for datasets and loaders."""
 
 import abc
+from typing import Iterator
 
 import literate_dataclasses as dataclasses
 import torch
@@ -254,19 +255,25 @@ class Loader(abc.ABC, cebra.io.HasDevice):
             raise ValueError(
                 f"Batch size has to be None, or a non-negative value. Got {self.batch_size}."
             )
+        if self.num_negatives is not None and self.num_negatives <= 0:
+            raise ValueError(
+                f"Number of negatives has to be None, or a non-negative value. Got {self.num_negatives}."
+            )
+
+        if self.num_negatives is None:
+            self.num_negatives = self.batch_size
 
     def __len__(self):
         """The number of batches returned when calling as an iterator."""
         return self.num_steps
 
-    def __iter__(self) -> Batch:
+    def __iter__(self) -> Iterator[Batch]:
         for _ in range(len(self)):
-            index = self.get_indices(num_samples=self.batch_size,
-                                     num_negatives=self.num_negatives)
+            index = self.get_indices()
             yield self.dataset.load_batch(index)
 
     @abc.abstractmethod
-    def get_indices(self, num_samples: int, num_negatives: int = None):
+    def get_indices(self):
         """Sample and return the specified number of indices.
 
         The elements of the returned `BatchIndex` will be used to index the

--- a/cebra/data/base.py
+++ b/cebra/data/base.py
@@ -239,6 +239,12 @@ class Loader(abc.ABC, cebra.io.HasDevice):
     batch_size: int = dataclasses.field(default=None,
                                         doc="""The total batch size.""")
 
+    num_negatives: int = dataclasses.field(
+        default=None,
+        doc="""The number of negative samples to draw for each reference.
+                                           If not specified, the batch size is used."""
+    )
+
     def __post_init__(self):
         if self.num_steps is None or self.num_steps <= 0:
             raise ValueError(
@@ -255,11 +261,12 @@ class Loader(abc.ABC, cebra.io.HasDevice):
 
     def __iter__(self) -> Batch:
         for _ in range(len(self)):
-            index = self.get_indices(num_samples=self.batch_size)
+            index = self.get_indices(num_samples=self.batch_size,
+                                     num_negatives=self.num_negatives)
             yield self.dataset.load_batch(index)
 
     @abc.abstractmethod
-    def get_indices(self, num_samples: int):
+    def get_indices(self, num_samples: int, num_negatives: int = None):
         """Sample and return the specified number of indices.
 
         The elements of the returned `BatchIndex` will be used to index the
@@ -271,5 +278,10 @@ class Loader(abc.ABC, cebra.io.HasDevice):
 
         Returns:
             batch indices for the reference, positive and negative sample.
+
+
+        Note:
+            From version 0.7.0 onwards, `num_negatives` parameter was added to allow
+            specifying a different number of negative samples compared to the batch size.
         """
         raise NotImplementedError()

--- a/cebra/data/base.py
+++ b/cebra/data/base.py
@@ -242,8 +242,8 @@ class Loader(abc.ABC, cebra.io.HasDevice):
 
     num_negatives: int = dataclasses.field(
         default=None,
-        doc="""The number of negative samples to draw for each reference.
-                                           If not specified, the batch size is used."""
+        doc=("The number of negative samples to draw for each reference. "
+             "If not specified, the batch size is used."),
     )
 
     def __post_init__(self):
@@ -273,23 +273,23 @@ class Loader(abc.ABC, cebra.io.HasDevice):
             yield self.dataset.load_batch(index)
 
     @abc.abstractmethod
-    def get_indices(self):
+    def get_indices(self, num_samples: int = None):
         """Sample and return the specified number of indices.
 
         The elements of the returned `BatchIndex` will be used to index the
         `dataset` of this data loader.
 
         Args:
-            num_samples: The size of each of the reference, positive and
-                negative samples.
+            num_samples: Deprecated. Use ``batch_size`` on the instance level
+                instead.
 
         Returns:
             batch indices for the reference, positive and negative sample.
 
-
         Note:
-            From version 0.7.0 onwards, specifying the ``num_samples`` and
-            ``num_negatives`` directly was deprecated. Please set these
-            variables via the attributes ``batch_size`` and ``num_negatives``.
+            From version 0.7.0 onwards, specifying the ``num_samples``
+            directly is deprecated and will be removed in version 0.8.0.
+            Please set ``batch_size`` and ``num_negatives`` on the instance
+            level instead.
         """
         raise NotImplementedError()

--- a/cebra/data/multi_session.py
+++ b/cebra/data/multi_session.py
@@ -160,9 +160,7 @@ class MultiSessionLoader(cebra_data.Loader):
 
     # NOTE(stes): In the longer run, we need to unify the API here; the num_samples argument
     # is not used in the multi-session case, which is different to the single session samples.
-    def get_indices(self,
-                    num_samples: int,
-                    num_negatives: int = None) -> List[BatchIndex]:
+    def get_indices(self) -> List[BatchIndex]:
         ref_idx = self.sampler.sample_prior(self.batch_size)
         neg_idx = self.sampler.sample_prior(self.num_negatives)
         pos_idx, idx, idx_rev = self.sampler.sample_conditional(ref_idx)
@@ -238,9 +236,14 @@ class UnifiedLoader(ContinuousMultiSessionDataLoader):
         self.sampler = cebra.distributions.UnifiedSampler(
             self.dataset, self.time_offset)
 
-    def get_indices(self,
-                    num_samples: int,
-                    num_negatives: int = None) -> BatchIndex:
+        if self.batch_size < 2:
+            raise ValueError("UnifiedLoader does not support batch_size < 2.")
+
+        if self.num_negatives < 2:
+            raise ValueError(
+                "UnifiedLoader does not support num_negatives < 2.")
+
+    def get_indices(self) -> BatchIndex:
         """Sample and return the specified number of indices.
 
         The elements of the returned ``BatchIndex`` will be used to index the

--- a/cebra/data/multi_session.py
+++ b/cebra/data/multi_session.py
@@ -155,10 +155,14 @@ class MultiSessionLoader(cebra_data.Loader):
         super().__post_init__()
         self.sampler = cebra.distributions.MultisessionSampler(
             self.dataset, self.time_offset)
+        if self.num_negatives is None:
+            self.num_negatives = self.batch_size
 
-    def get_indices(self, num_samples: int) -> List[BatchIndex]:
+    # NOTE(stes): In the longer run, we need to unify the API here; the num_samples argument
+    # is not used in the multi-session case, which is different to the single session samples.
+    def get_indices(self, num_samples) -> List[BatchIndex]:
         ref_idx = self.sampler.sample_prior(self.batch_size)
-        neg_idx = self.sampler.sample_prior(self.batch_size)
+        neg_idx = self.sampler.sample_prior(self.num_negatives)
         pos_idx, idx, idx_rev = self.sampler.sample_conditional(ref_idx)
 
         ref_idx = torch.from_numpy(ref_idx)
@@ -251,7 +255,7 @@ class UnifiedLoader(ContinuousMultiSessionDataLoader):
             Batch indices for the reference, positive and negative samples.
         """
         ref_idx = self.sampler.sample_prior(self.batch_size)
-        neg_idx = self.sampler.sample_prior(self.batch_size)
+        neg_idx = self.sampler.sample_prior(self.num_negatives)
 
         pos_idx = self.sampler.sample_conditional(ref_idx)
 

--- a/cebra/data/multi_session.py
+++ b/cebra/data/multi_session.py
@@ -160,7 +160,9 @@ class MultiSessionLoader(cebra_data.Loader):
 
     # NOTE(stes): In the longer run, we need to unify the API here; the num_samples argument
     # is not used in the multi-session case, which is different to the single session samples.
-    def get_indices(self, num_samples) -> List[BatchIndex]:
+    def get_indices(self,
+                    num_samples: int,
+                    num_negatives: int = None) -> List[BatchIndex]:
         ref_idx = self.sampler.sample_prior(self.batch_size)
         neg_idx = self.sampler.sample_prior(self.num_negatives)
         pos_idx, idx, idx_rev = self.sampler.sample_conditional(ref_idx)

--- a/cebra/data/multi_session.py
+++ b/cebra/data/multi_session.py
@@ -198,8 +198,11 @@ class DiscreteMultiSessionDataLoader(MultiSessionLoader):
     # Overwrite sampler with the discrete implementation
     # Generalize MultisessionSampler to avoid doing this?
     def __post_init__(self):
+        # NOTE(stes): __post_init__ from superclass is intentionally not called.
         self.sampler = cebra.distributions.DiscreteMultisessionSampler(
             self.dataset)
+        if self.num_negatives is None:
+            self.num_negatives = self.batch_size
 
     @property
     def index(self):
@@ -235,7 +238,9 @@ class UnifiedLoader(ContinuousMultiSessionDataLoader):
         self.sampler = cebra.distributions.UnifiedSampler(
             self.dataset, self.time_offset)
 
-    def get_indices(self, num_samples: int) -> BatchIndex:
+    def get_indices(self,
+                    num_samples: int,
+                    num_negatives: int = None) -> BatchIndex:
         """Sample and return the specified number of indices.
 
         The elements of the returned ``BatchIndex`` will be used to index the

--- a/cebra/data/multi_session.py
+++ b/cebra/data/multi_session.py
@@ -236,10 +236,10 @@ class UnifiedLoader(ContinuousMultiSessionDataLoader):
         self.sampler = cebra.distributions.UnifiedSampler(
             self.dataset, self.time_offset)
 
-        if self.batch_size < 2:
+        if self.batch_size is not None and self.batch_size < 2:
             raise ValueError("UnifiedLoader does not support batch_size < 2.")
 
-        if self.num_negatives < 2:
+        if self.num_negatives is not None and self.num_negatives < 2:
             raise ValueError(
                 "UnifiedLoader does not support num_negatives < 2.")
 

--- a/cebra/data/multiobjective.py
+++ b/cebra/data/multiobjective.py
@@ -71,7 +71,7 @@ class SupervisedMultiObjectiveLoader(MultiObjectiveLoader):
     def add_config(self, config):
         self.labels.append(config['label'])
 
-    def get_indices(self, num_samples: int):
+    def get_indices(self, num_samples: int, num_negatives: int = None):
         if self.sampling_mode_supervised == "ref_shared":
             reference_idx = self.prior.sample_prior(num_samples)
         else:
@@ -142,11 +142,14 @@ class ContrastiveMultiObjectiveLoader(MultiObjectiveLoader):
 
         self.distributions.append(distribution)
 
-    def get_indices(self, num_samples: int):
+    def get_indices(self, num_samples: int, num_negatives: int = None):
         """Sample and return the specified number of indices."""
 
+        if num_negatives is None:
+            num_negatives = num_samples
+
         if self.sampling_mode_contrastive == "refneg_shared":
-            ref_and_neg = self.prior.sample_prior(num_samples * 2)
+            ref_and_neg = self.prior.sample_prior(num_samples + num_negatives)
             reference_idx = ref_and_neg[:num_samples]
             negative_idx = ref_and_neg[num_samples:]
 
@@ -169,5 +172,6 @@ class ContrastiveMultiObjectiveLoader(MultiObjectiveLoader):
 
     def __iter__(self):
         for _ in range(len(self)):
-            index = self.get_indices(num_samples=self.batch_size)
+            index = self.get_indices(num_samples=self.batch_size,
+                                     num_negatives=self.num_negatives)
             yield self.dataset.load_batch_contrastive(index)

--- a/cebra/data/multiobjective.py
+++ b/cebra/data/multiobjective.py
@@ -20,10 +20,13 @@
 # limitations under the License.
 #
 
+from typing import Iterator
+
 import literate_dataclasses as dataclasses
 
 import cebra.data as cebra_data
 import cebra.distributions
+from cebra.data.datatypes import Batch
 from cebra.data.datatypes import BatchIndex
 from cebra.distributions.continuous import Prior
 
@@ -71,9 +74,9 @@ class SupervisedMultiObjectiveLoader(MultiObjectiveLoader):
     def add_config(self, config):
         self.labels.append(config['label'])
 
-    def get_indices(self, num_samples: int, num_negatives: int = None):
+    def get_indices(self) -> BatchIndex:
         if self.sampling_mode_supervised == "ref_shared":
-            reference_idx = self.prior.sample_prior(num_samples)
+            reference_idx = self.prior.sample_prior(self.batch_size)
         else:
             raise ValueError(
                 f"Sampling mode {self.sampling_mode_supervised} is not implemented."
@@ -87,9 +90,9 @@ class SupervisedMultiObjectiveLoader(MultiObjectiveLoader):
 
         return batch_index
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Batch]:
         for _ in range(len(self)):
-            index = self.get_indices(num_samples=self.batch_size)
+            index = self.get_indices()
             yield self.dataset.load_batch_supervised(index, self.labels)
 
 
@@ -142,16 +145,14 @@ class ContrastiveMultiObjectiveLoader(MultiObjectiveLoader):
 
         self.distributions.append(distribution)
 
-    def get_indices(self, num_samples: int, num_negatives: int = None):
+    def get_indices(self) -> BatchIndex:
         """Sample and return the specified number of indices."""
 
-        if num_negatives is None:
-            num_negatives = num_samples
-
         if self.sampling_mode_contrastive == "refneg_shared":
-            ref_and_neg = self.prior.sample_prior(num_samples + num_negatives)
-            reference_idx = ref_and_neg[:num_samples]
-            negative_idx = ref_and_neg[num_samples:]
+            ref_and_neg = self.prior.sample_prior(self.batch_size +
+                                                  self.num_negatives)
+            reference_idx = ref_and_neg[:self.batch_size]
+            negative_idx = ref_and_neg[self.batch_size:]
 
             positives_idx = []
             for distribution in self.distributions:
@@ -172,6 +173,5 @@ class ContrastiveMultiObjectiveLoader(MultiObjectiveLoader):
 
     def __iter__(self):
         for _ in range(len(self)):
-            index = self.get_indices(num_samples=self.batch_size,
-                                     num_negatives=self.num_negatives)
+            index = self.get_indices()
             yield self.dataset.load_batch_contrastive(index)

--- a/cebra/data/single_session.py
+++ b/cebra/data/single_session.py
@@ -152,11 +152,6 @@ class DiscreteDataLoader(cebra_data.Loader):
         The negative samples will be sampled from the same distribution as the
         reference examples.
 
-        Args:
-            num_samples: The number of samples (batch size) of the returned
-                :py:class:`cebra.data.datatypes.BatchIndex`.
-            num_negatives: The number of negative samples. If None, defaults to num_samples.
-
         Returns:
             Indices for reference, positive and negatives samples.
         """
@@ -258,10 +253,6 @@ class ContinuousDataLoader(cebra_data.Loader):
         The positive samples will be sampled conditional on the reference
         samples according to the specified ``conditional`` distribution.
 
-        Args:
-            num_samples: The number of samples (batch size) of the returned
-                :py:class:`cebra.data.datatypes.BatchIndex`.
-
         Returns:
             Indices for reference, positive and negatives samples.
         """
@@ -319,11 +310,6 @@ class MixedDataLoader(cebra_data.Loader):
         the reference samples, and then sampled as in the
         :py:class:`ContinuousDataLoader`, or just sampled based on the
         conditional variable.
-
-        Args:
-            num_samples: The number of samples (batch size) of the returned
-                :py:class:`cebra.data.datatypes.BatchIndex`.
-            num_negatives: The number of negative samples. If None, defaults to num_samples.
 
         Returns:
             Indices for reference, positive and negatives samples.
@@ -433,18 +419,13 @@ class HybridDataLoader(cebra_data.Loader):
         """Samples indices for reference, positive and negative examples.
 
         The reference and negative samples will be sampled uniformly from
-        all available time steps, and a total of ``num_samples + num_negatives`` will be
-        returned for both.
+        all available time steps, and a total of ``self.batch_size + self.num_negatives``
+        will be returned for both.
 
-        For the positive samples, ``num_samples`` are sampled according to the
-        behavior conditional distribution, and another ``num_samples`` are
-        sampled according to the dime contrastive distribution. The indices
+        For the positive samples, ``self.batch_size`` samples are sampled according to the
+        behavior conditional distribution, and another ``self.batch_size`` samples are
+        sampled according to the time contrastive distribution. The indices
         for the positive samples are concatenated across the first dimension.
-
-        Args:
-            num_samples: The number of samples (batch size) of the returned
-                :py:class:`cebra.data.datatypes.BatchIndex`.
-            num_negatives: The number of negative samples. If None, defaults to num_samples.
 
         Returns:
             Indices for reference, positive and negatives samples.

--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -504,6 +504,9 @@ class CEBRA(TransformerMixin, BaseEstimator):
             A Tuple of masking types and their corresponding required masking values. The keys are the
             names of the Mask instances and formatting should be ``((key, value), (key, value))``.
             |Default:| ``None``.
+        num_negatives (int):
+            The number of negative samples to use for training. If ``None``, the number of negative samples
+            will be set to the batch size. |Default:| ``None``.
 
     Example:
 
@@ -579,6 +582,7 @@ class CEBRA(TransformerMixin, BaseEstimator):
         ),
         masking_kwargs: Tuple[Tuple[str, Union[float, List[float],
                                                Tuple[float, ...]]], ...] = None,
+        num_negatives: int = None,
     ):
         self.__dict__.update(locals())
 
@@ -731,6 +735,7 @@ class CEBRA(TransformerMixin, BaseEstimator):
                 dataset=dataset,
                 batch_size=self.batch_size,
                 num_steps=max_iterations,
+                num_negatives=self.num_negatives,
             ),
             extra_kwargs=dict(
                 time_offsets=self.time_offsets,

--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -600,8 +600,12 @@ class CEBRA(TransformerMixin, BaseEstimator):
         return self.num_sessions_
 
     @property
-    def num_negatives_(self) -> int:
-        """The number of negative examples."""
+    def num_negatives_(self) -> Optional[int]:
+        """The number of negative examples.
+
+        If the model is trained using the full dataset (``batch_size`` is ``None``), this
+        function will return ``None``.
+        """
         if self.num_negatives is None:
             return self.batch_size
         return self.num_negatives

--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -600,6 +600,13 @@ class CEBRA(TransformerMixin, BaseEstimator):
         return self.num_sessions_
 
     @property
+    def num_negatives_(self) -> int:
+        """The number of negative examples."""
+        if self.num_negatives is None:
+            return self.batch_size
+        return self.num_negatives
+
+    @property
     def state_dict_(self) -> dict:
         return self.solver_.state_dict()
 

--- a/cebra/integrations/sklearn/metrics.py
+++ b/cebra/integrations/sklearn/metrics.py
@@ -100,12 +100,12 @@ def infonce_loss(
     solver.to(cebra_model.device_)
     avg_loss = solver.validation(loader=loader, session_id=session_id)
     if correct_by_batchsize:
-        if cebra_model.batch_size is None:
+        if cebra_model.num_negatives_ is None:
             raise ValueError(
                 "Batch size is None, please provide a model with a batch size to correct the InfoNCE."
             )
         else:
-            avg_loss = avg_loss - np.log(cebra_model.batch_size)
+            avg_loss = avg_loss - np.log(cebra_model.num_negatives_)
     return avg_loss
 
 
@@ -211,7 +211,7 @@ def infonce_to_goodness_of_fit(
     Args:
         infonce: The InfoNCE loss, either a single value or an iterable of values.
         model: The trained CEBRA model.
-        batch_size: The batch size used to train the model.
+        batch_size: The batch size (or number of negatives, if different from the batch size) used to train the model.
         num_sessions: The number of sessions used to train the model.
 
     Returns:
@@ -228,19 +228,15 @@ def infonce_to_goodness_of_fit(
             )
         if not hasattr(model, "state_dict_"):
             raise RuntimeError("Fit the CEBRA model first.")
-        if model.batch_size is None:
+        if model.num_negatives_ is None:
             raise ValueError(
                 "Computing the goodness of fit is not yet supported for "
                 "models trained on the full dataset (batchsize = None). ")
-        batch_size = model.batch_size
+        batch_size = model.num_negatives_
         num_sessions = model.num_sessions_
         if num_sessions is None:
             num_sessions = 1
 
-        if model.batch_size is None:
-            raise ValueError(
-                "Computing the goodness of fit is not yet supported for "
-                "models trained on the full dataset (batchsize = None). ")
     else:
         if batch_size is None or num_sessions is None:
             raise ValueError(

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1544,3 +1544,20 @@ def test_last_incomplete_batch_smaller_than_offset():
     model.fit(train.neural, train.continuous)
 
     _ = model.transform(train.neural, batch_size=300)
+
+
+@pytest.mark.parametrize("batch_size,num_negatives", [
+    (None, None),
+    (100, None),
+    (100, 100),
+])
+def test_num_negatives(batch_size, num_negatives):
+    train = cebra.data.TensorDataset(neural=np.random.rand(20111, 100),
+                                     continuous=np.random.rand(20111, 2))
+
+    model = cebra.CEBRA(max_iterations=2,
+                        batch_size=batch_size,
+                        num_negatives=num_negatives,
+                        device="cpu")
+    model.fit(train.neural, train.continuous)
+    _ = model.transform(train.neural)


### PR DESCRIPTION
This PR adds a new argument, `num_negatives`, to both the `Loader` and `CEBRA` classes (torch and sklearn API). This allows to stabilize training behavior by providing additional negative examples to the InfoNCE loss independent of the batch size. We leveraged this logic for the models trained in [DCL](https://openreview.net/forum?id=ONfWFluZBI).

### Behavior

If the `num_negatives = None` (the default), the previous behavior is obtained for backwards compatibility and `Loader.batch_size` negative examples are drawn. If a different value is set, then the number of negative examples in all loaders will be set to `num_negatives` instead of `Loader.batch_size`.

The goodness of fit computation was also adapted to use the `num_negatives`.

### API modification

While implementing this functionality, I noticed an inconsistency between `single_session` and `multi_session` solvers. In the single session, we passed `self.batch_size` through the `get_indices` function, while in `multi_session` we use `self.batch_size` directly. The 2nd behavior makes more sense in the context of the general class design. I deprecated passing the `num_samples` parameter and adapted the samplers accordingly.