### PR TITLE
Fix matplotlib colormap deprecation warnings for 3.11 compatibility

### DIFF
--- a/cebra/integrations/matplotlib.py
+++ b/cebra/integrations/matplotlib.py
@@ -1235,7 +1235,7 @@ def compare_models(
 
     # check the color of the traces
     if color is None:
-        cebra_map = plt.get_cmap(cmap)
+        cebra_map = matplotlib.colormaps.get_cmap(cmap)
         colors = matplotlib.colors.ListedColormap(
             cebra_map.resampled(n_models)(np.arange(n_models))).colors
     else:

--- a/cebra/integrations/plotly.py
+++ b/cebra/integrations/plotly.py
@@ -87,7 +87,7 @@ class _EmbeddingInteractivePlot(_EmbeddingPlot):
         Returns:
             colorscale: List of scaled colors to plot the embeddings
         """
-        colorscale = _convert_cmap2colorscale(matplotlib.cm.get_cmap(cmap))
+        colorscale = _convert_cmap2colorscale(matplotlib.colormaps.get_cmap(cmap))
 
         return colorscale
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,7 @@ install_requires =
     scipy
     torch>=2.4.0
     tqdm
-    # NOTE(stes): Remove pin once https://github.com/AdaptiveMotorControlLab/CEBRA/issues/240
-    # is resolved.
-    matplotlib<3.11
+    matplotlib
     requests
 
 [options.extras_require]

--- a/tests/test_plotly.py
+++ b/tests/test_plotly.py
@@ -31,7 +31,7 @@ import cebra.integrations.sklearn.cebra as cebra_sklearn_cebra
 
 @pytest.mark.parametrize("cmap", ["viridis", "plasma", "inferno", "magma"])
 def test_colorscale(cmap):
-    cmap = matplotlib.cm.get_cmap(cmap)
+    cmap = matplotlib.colormaps.get_cmap(cmap)
     colorscale = cebra_plotly._convert_cmap2colorscale(cmap)
     assert isinstance(colorscale, list)
 


### PR DESCRIPTION
- Replace matplotlib.cm.get_cmap() with matplotlib.colormaps.get_cmap()
- Replace plt.get_cmap() with matplotlib.colormaps.get_cmap()
- Update cebra/integrations/plotly.py, matplotlib.py, and tests/test_plotly.py
- Remove matplotlib<3.11 version pin from setup.cfg
- Ensures future compatibility with matplotlib 3.11+ releases

Fixes #240