### PR TITLE
Fix docs build for numpy 2.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,4 +19,6 @@ sphinxcontrib-serializinghtml==2.0.0
 literate_dataclasses
 # For IPython.sphinxext.ipython_console_highlighting extension
 ipython
-numpy
+# TODO(stes): temporary fix, remove once objects.inv are updated
+# see https://github.com/AdaptiveMotorControlLab/CEBRA/issues/303
+numpy<2.5


### PR DESCRIPTION
Fix for #303 . Does not need to be necessarily merged. It might be that the files are updated within the next couple days.