### PR TITLE
Support numpy2 on windows

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,4 +19,6 @@ sphinxcontrib-serializinghtml==2.0.0
 literate_dataclasses
 # For IPython.sphinxext.ipython_console_highlighting extension
 ipython
-numpy
+# TODO(stes): temporary fix, remove once objects.inv are updated
+# see https://github.com/AdaptiveMotorControlLab/CEBRA/issues/303
+numpy<2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,7 @@ where =
 python_requires = >=3.10
 install_requires =
     joblib
-    numpy<2.0;platform_system=="Windows"
-    numpy;platform_system!="Windows" and python_version>="3.10"
+    numpy<2.5
     literate-dataclasses
     scikit-learn
     scipy


### PR DESCRIPTION
In the past, there was a compatibility issue on windows with numpy 2. It seems this issue is fixed now and there is interest to use numpy 2 on windows.

Parallel to this effort, numpy 2.5 was released. This breaks our docs build pipeline at one point. As a temporary measure we can expect to lift in a few weeks, I am pinning the max numpy version < 2.5.

Fix #303
Fix #305 